### PR TITLE
Add design-sync inputs for Claude Design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -27,8 +27,9 @@ Repo-specific gotchas for future syncs.
 - **`Header` / `PostSection`**: compound components expecting structured data (list of [label,href], text arrays) — compose from real app page examples.
 
 ## Scope decision (this run)
-- **Minimal mode**: all 20 components shipped with the deterministic **floor card** (functional + `.d.ts` + `.prompt.md`); no example previews authored. Rich previews can be authored on any future re-sync (per-component, in `.design-sync/previews/<Name>.tsx`).
+- Started minimal (floor cards), then authored **rich previews for all 20 components** in `.design-sync/previews/*.tsx` (committed). Stories ported from the app pages (Homepage/Lore/Terrariums/Dev/Instructions/Contacts) + locales.
 - Conventions header authored (`.design-sync/conventions.md`, wired via `readmeHeader`) — teaches the Claude Design agent the provider wrap + `.g-*` idiom + tokens.
+- Previews compile clean (20 user-owned, 0 failed) but were **NOT machine-verified** (render check skipped — no Playwright). Reviewed via local `.review.html`. Image-based previews (PostSection/GorliumImage) use an inline SVG data-URI placeholder since app asset paths don't resolve in cards.
 
 ## Re-sync risks
 - If Playwright is installed on a future run, drop `--no-render-check` to machine-verify previews. The driver (`resync.mjs`) chains capture which needs Playwright — without it, run `package-build.mjs` + `package-validate.mjs --no-render-check` manually instead of the one-command driver.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,35 @@
+# design-sync notes — @gorlium/design-system
+
+Repo-specific gotchas for future syncs.
+
+## Build / converter
+- Shape: **package** (React lib built with tsup/esbuild; no Storybook).
+- Built ESM entry: `packages/design-system/dist/index.mjs`; bundled CSS: `dist/index.css` (tokens + `.g-*` styles in one file).
+- Build command: `pnpm -F "@gorlium/design-system" build` (tsup `--minify --clean`). Use `COREPACK_ENABLE_STRICT=0` to avoid corepack pnpm self-provisioning.
+- Converter `--entry` resolves relative to **cwd (repo root)** — pass `./packages/design-system/dist/index.mjs`, not `./dist/...`.
+- `--node-modules ./packages/design-system/node_modules` (react/react-dom resolve there).
+- 20 component value exports (incl. `Column` and the `GorliumProvider` wrapper). `LanguageSwitch` is NOT exported from index (internal to Header) → not in bundle.
+
+## Provider / styling idiom
+- All components must render inside **`GorliumProvider`** (renders `<div className="g-root">`), which applies the dark brutalist scope: `--g-bg` background, `--g-ink` text, mono font, box-sizing. `cfg.provider.component = "GorliumProvider"`.
+- Styling idiom: namespaced global `.g-*` classes (NOT CSS modules, NOT utility classes). Components style themselves; consumers compose via props.
+- Tokens are CSS custom properties `--g-*` (colors, `--g-space-*` scale, `--g-bw` border width, `--g-radius` 0px, `--g-shadow` hard-offset). Defined in `dist/index.css`.
+
+## Fonts
+- Space Grotesk (display) + Space Mono (body) load via a **remote Google Fonts `@import`** in tokens.css → `[FONT_REMOTE]`, loads at runtime. No fonts shipped. No action.
+
+## Render check
+- **Render check SKIPPED this run** (user declined Playwright/Chromium ~200MB install). Bundle built + validated with `--no-render-check`; structural checks (dscard, css imports, fonts, anchor) all passed. Previews were NOT machine-verified — relied on served `.review.html` for visual review in the user's own browser.
+
+## Render-quality risks (re-sync watch-list)
+- **`vh`-based font sizes**: typography (`.g-title`, `.g-body`) and many sizes use `vh` units (e.g. `font-size: 4vh`). Preview cards with small/large viewports will render text proportionally tiny/huge. Author previews with a sane card viewport in mind.
+- **`GorliumImage` `path` prop**: loads images from the app's asset paths — images will NOT resolve in previews. Author with placeholder-friendly framing or skip image-dependent stories.
+- **`Header` / `PostSection`**: compound components expecting structured data (list of [label,href], text arrays) — compose from real app page examples.
+
+## Scope decision (this run)
+- **Minimal mode**: all 20 components shipped with the deterministic **floor card** (functional + `.d.ts` + `.prompt.md`); no example previews authored. Rich previews can be authored on any future re-sync (per-component, in `.design-sync/previews/<Name>.tsx`).
+- Conventions header authored (`.design-sync/conventions.md`, wired via `readmeHeader`) — teaches the Claude Design agent the provider wrap + `.g-*` idiom + tokens.
+
+## Re-sync risks
+- If Playwright is installed on a future run, drop `--no-render-check` to machine-verify previews. The driver (`resync.mjs`) chains capture which needs Playwright — without it, run `package-build.mjs` + `package-validate.mjs --no-render-check` manually instead of the one-command driver.
+- This is a **one-way** sync (repo → Claude Design component library). UI designs produced IN Claude Design must be brought back to the repo manually.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,12 @@
+{
+  "projectId": "8e91b7c6-753a-4a54-bf34-cbb9a1662cd5",
+  "shape": "package",
+  "pkg": "@gorlium/design-system",
+  "globalName": "Gorlium",
+  "buildCmd": "pnpm -F \"@gorlium/design-system\" build",
+  "cssEntry": "dist/index.css",
+  "provider": {
+    "component": "GorliumProvider"
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,42 @@
+# Gorlium design system — conventions
+
+Digital-brutalism React component library. Dark canvas, hard edges (0px radius), 2px borders, hard-offset shadows (no blur), acid-lime + terracotta accents, monospace/grotesk type. Build with the components below — never hand-roll lookalikes.
+
+## Wrapping (required)
+
+Every screen must be wrapped in **`<GorliumProvider>`**. It renders `<div className="g-root">`, which applies the dark background (`--g-bg`), default ink color (`--g-ink`), the monospace font, and `box-sizing: border-box` to everything inside. Without it components render on a white page in a default serif font — broken.
+
+```jsx
+import { GorliumProvider, Stack, Title, Body, Button } from "@gorlium/design-system";
+
+<GorliumProvider>
+  <Stack space={24} align="center">
+    <Title size="large">GORLIUM</Title>
+    <Body size="medium">A tiny self-contained ecosystem.</Body>
+    <Button label="SEND" kind="solid" onPress={() => {}} />
+  </Stack>
+</GorliumProvider>
+```
+
+## Styling idiom
+
+The DS styles itself through **namespaced global `.g-*` classes** (NOT CSS modules, NOT utility classes). You do not write `.g-*` classes — components emit them. Style your own layout glue with inline styles or by composing the layout primitives. Do not invent a class vocabulary; there is none to invent.
+
+Design tokens are CSS custom properties on `:root` (read them with `var(--…)` for any custom styling):
+
+- **Colors**: `--g-bg` `#0b0b0b`, `--g-surface` `#141414`, `--g-surface-2` `#1c1c1c`, `--g-ink` `#ececec`, `--g-ink-dim` `#8a8a8a`, `--g-accent` `#c9f24d` (acid lime), `--g-accent-2` `#ff5a1f` (terracotta), `--g-border` `#2e2e2e`, `--g-border-strong` `#ececec`.
+- **Shape**: `--g-radius` `0px`, `--g-bw` `2px` (border width), `--g-shadow` `4px 4px 0 0 var(--g-ink)`, `--g-shadow-accent` `4px 4px 0 0 var(--g-accent)`.
+- **Type**: `--g-font-display` ("Space Grotesk"), `--g-font-mono` ("Space Mono"). Loaded at runtime from Google Fonts.
+- **Space scale** (use for `space`/`gap` props and custom spacing): `--g-space-0/4/8/12/16/24/32/40/80`.
+
+Note: typography (`Title`, `Body`) sizes in `vh` units — they scale with viewport height.
+
+## Components
+
+- **Layout primitives**: `Box` (padding/width/height props), `Stack` (vertical, `space`, `align`, `dividers`), `Inline` (horizontal, `space`, `alignY`, `collapseBelow`), `Columns` + `Column` (`width`: `"content"` | `"1/2"` | px), `Tiles` (responsive grid, `columns`).
+- **Type**: `Title` (`size`: large/medium/small, `align`), `Body` (`size`: small/medium/large, `align`).
+- **Actions**: `Button` (`label`, `kind`: solid/transparent, `hierarchy`, `size`: medium/large, `onPress`, optional `icon`), `Link` (`href`, `children`).
+- **Form**: `Form` (`title`, `description`, `error`, `submitButton: {label, onPress}`), `FormSection`, `TextField` (`label`, `value`, `onChange`), `TextArea` (+ `rows`).
+- **Composite**: `Header` (`list: [label, href][]` nav), `Banner` (scrolling marquee, wraps children), `PostSection` (`title` + `text: string[]` + optional `imgPath`/`imgSize`/`imgAlignRight`), `GorliumImage` (`path`, `opacity`, overlay `children`), `WeirdFlex` (centered column flex, `gap`).
+
+Read each component's `<Name>.d.ts` for its exact prop contract and `<Name>.prompt.md` for usage before composing. The full styling source is in `_ds_bundle.css` (reachable from `styles.css`).

--- a/.design-sync/previews/Banner.tsx
+++ b/.design-sync/previews/Banner.tsx
@@ -1,0 +1,9 @@
+import { Banner, Title } from "@gorlium/design-system";
+
+// Banner scrolls its children horizontally (marquee). Static capture shows the
+// repeated content tiled across the width.
+export const Welcome = () => (
+  <Banner>
+    <Title size="medium">| WELCOME TO THE GORLIUM |</Title>
+  </Banner>
+);

--- a/.design-sync/previews/Body.tsx
+++ b/.design-sync/previews/Body.tsx
@@ -1,0 +1,16 @@
+import { Body, Stack } from "@gorlium/design-system";
+
+export const Sizes = () => (
+  <Stack space={16}>
+    <Body size="large">Those tiny jars of greenery are like a whole world in miniature.</Body>
+    <Body size="medium">Terrariums are about balance — and soil is at the heart of that.</Body>
+    <Body size="small">PS. This fucker and his brother eat all my plants.</Body>
+  </Stack>
+);
+
+export const Paragraphs = () => (
+  <Body size="medium" align="left">
+    <p>The first time I made a terrarium, I failed spectacularly.</p>
+    <p>I thought I could just throw some plants into a jar, and they'd thrive. Spoiler: they didn't.</p>
+  </Body>
+);

--- a/.design-sync/previews/Box.tsx
+++ b/.design-sync/previews/Box.tsx
@@ -1,0 +1,19 @@
+import { Box, Body } from "@gorlium/design-system";
+
+export const Padded = () => (
+  <Box padding={24} style={{ border: "2px solid var(--g-border)", background: "var(--g-surface)" }}>
+    <Body size="medium">A padded box on the surface color.</Body>
+  </Box>
+);
+
+export const Sized = () => (
+  <Box width={240} height={120} padding={16} style={{ background: "var(--g-accent)", color: "#0b0b0b" }}>
+    <Body size="small">240 × 120 box with acid-lime fill.</Body>
+  </Box>
+);
+
+export const FullWidth = () => (
+  <Box width="full" padding={16} style={{ border: "2px solid var(--g-accent)" }}>
+    <Body size="medium">Full-width box.</Body>
+  </Box>
+);

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,30 @@
+import { Button, Inline } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const Solid = () => <Button label="SEND" kind="solid" onPress={noop} />;
+
+export const Transparent = () => (
+  <Button label="This website GitHub repo" kind="transparent" hierarchy="primary" onPress={noop} />
+);
+
+export const Large = () => <Button label="GET A TERRARIUM" kind="solid" size="large" onPress={noop} />;
+
+export const WithIcon = () => (
+  <Button
+    label="STAR ON GITHUB"
+    kind="solid"
+    size="large"
+    icon={({ size }) => (
+      <span style={{ fontSize: size, lineHeight: 1 }}>★</span>
+    )}
+    onPress={noop}
+  />
+);
+
+export const Kinds = () => (
+  <Inline space={16} alignY="center">
+    <Button label="SOLID" kind="solid" onPress={noop} />
+    <Button label="TRANSPARENT" kind="transparent" onPress={noop} />
+  </Inline>
+);

--- a/.design-sync/previews/Column.tsx
+++ b/.design-sync/previews/Column.tsx
@@ -1,0 +1,22 @@
+import { Columns, Column, Box, Body } from "@gorlium/design-system";
+
+const cell = (label: string, bg: string) => (
+  <Box padding={16} style={{ background: bg, color: "#0b0b0b", height: "100%" }}>
+    <Body size="small">{label}</Body>
+  </Box>
+);
+
+// Column only renders meaningfully inside Columns — each story is the full parent.
+export const Content = () => (
+  <Columns space={16}>
+    <Column width="content">{cell('width="content"', "var(--g-accent)")}</Column>
+    <Column>{cell("default (fluid)", "var(--g-surface-2)")}</Column>
+  </Columns>
+);
+
+export const Fraction = () => (
+  <Columns space={16}>
+    <Column width="1/3">{cell('1/3', "var(--g-accent)")}</Column>
+    <Column width="2/3">{cell('2/3', "var(--g-accent-2)")}</Column>
+  </Columns>
+);

--- a/.design-sync/previews/Columns.tsx
+++ b/.design-sync/previews/Columns.tsx
@@ -1,0 +1,28 @@
+import { Columns, Column, Box, Body } from "@gorlium/design-system";
+
+const cell = (label: string, bg: string) => (
+  <Box padding={16} style={{ background: bg, color: "#0b0b0b", height: "100%" }}>
+    <Body size="small">{label}</Body>
+  </Box>
+);
+
+export const Even = () => (
+  <Columns space={16}>
+    <Column>{cell("Left", "var(--g-accent)")}</Column>
+    <Column>{cell("Right", "var(--g-accent-2)")}</Column>
+  </Columns>
+);
+
+export const FixedAndFluid = () => (
+  <Columns space={16}>
+    <Column width="content">{cell("content", "var(--g-accent)")}</Column>
+    <Column>{cell("fills remaining space", "var(--g-surface-2)")}</Column>
+  </Columns>
+);
+
+export const HalfHalf = () => (
+  <Columns space={16}>
+    <Column width="1/2">{cell("1/2", "var(--g-accent)")}</Column>
+    <Column width="1/2">{cell("1/2", "var(--g-accent-2)")}</Column>
+  </Columns>
+);

--- a/.design-sync/previews/Form.tsx
+++ b/.design-sync/previews/Form.tsx
@@ -1,0 +1,29 @@
+import { Form, FormSection, TextField, TextArea } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const ContactForm = () => (
+  <Form
+    title="Do you want a terrarium?"
+    description="Write me a message 💌 and remember to leave your contact info"
+    submitButton={{ label: "SEND", onPress: noop }}
+  >
+    <FormSection>
+      <TextField name="name" label="Name" placeholder="Type your name here..." value="" onChange={noop} />
+      <TextArea name="message" label="Message" placeholder="Type your message here..." rows={6} value="" onChange={noop} />
+    </FormSection>
+  </Form>
+);
+
+export const WithError = () => (
+  <Form
+    title="Do you want a terrarium?"
+    error="Please fill in all the fields 🥲"
+    errorBannerWidth="fill"
+    submitButton={{ label: "SEND", onPress: noop }}
+  >
+    <FormSection>
+      <TextField name="name" label="Name" value="" onChange={noop} />
+    </FormSection>
+  </Form>
+);

--- a/.design-sync/previews/FormSection.tsx
+++ b/.design-sync/previews/FormSection.tsx
@@ -1,0 +1,14 @@
+import { FormSection, TextField, TextArea } from "@gorlium/design-system";
+
+const noop = () => {};
+
+// FormSection groups related fields with consistent spacing; shown inside its
+// natural container.
+export const TwoFields = () => (
+  <div className="g-form" style={{ maxWidth: 480 }}>
+    <FormSection>
+      <TextField name="name" label="Name" placeholder="Type your name here..." value="" onChange={noop} />
+      <TextArea name="message" label="Message" placeholder="Type your message here..." rows={4} value="" onChange={noop} />
+    </FormSection>
+  </div>
+);

--- a/.design-sync/previews/GorliumImage.tsx
+++ b/.design-sync/previews/GorliumImage.tsx
@@ -1,0 +1,24 @@
+import { GorliumImage, Title } from "@gorlium/design-system";
+
+const IMG =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='480' height='360'%3E%3Crect width='100%25' height='100%25' fill='%231c1c1c'/%3E%3Crect x='10' y='10' width='460' height='340' fill='none' stroke='%23c9f24d' stroke-width='4'/%3E%3Ctext x='50%25' y='50%25' fill='%23c9f24d' font-family='monospace' font-size='30' text-anchor='middle' dominant-baseline='middle'%3ETERRARIUM%3C/text%3E%3C/svg%3E";
+
+export const Basic = () => (
+  <div style={{ height: 280 }}>
+    <GorliumImage path={IMG} height="280px" />
+  </div>
+);
+
+export const Dimmed = () => (
+  <div style={{ height: 280 }}>
+    <GorliumImage path={IMG} opacity={0.4} height="280px" />
+  </div>
+);
+
+export const WithOverlay = () => (
+  <div style={{ height: 280 }}>
+    <GorliumImage path={IMG} opacity={0.6} height="280px">
+      <Title size="large">GORLIUM</Title>
+    </GorliumImage>
+  </div>
+);

--- a/.design-sync/previews/GorliumProvider.tsx
+++ b/.design-sync/previews/GorliumProvider.tsx
@@ -1,0 +1,15 @@
+import { GorliumProvider, Stack, Title, Body, Button } from "@gorlium/design-system";
+
+const noop = () => {};
+
+// The root wrapper. It applies the dark brutalist scope (.g-root): background,
+// ink color, monospace font. Every screen should be wrapped in it.
+export const Scope = () => (
+  <GorliumProvider>
+    <Stack space={16} align="center">
+      <Title size="large">GORLIUM</Title>
+      <Body size="medium">Everything inside renders on the dark canvas with the mono font.</Body>
+      <Button label="GET A TERRARIUM" kind="solid" size="large" onPress={noop} />
+    </Stack>
+  </GorliumProvider>
+);

--- a/.design-sync/previews/Header.tsx
+++ b/.design-sync/previews/Header.tsx
@@ -1,0 +1,17 @@
+import { Header } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const Navigation = () => (
+  <Header
+    initialLanguage="it"
+    onToggleLanguage={noop}
+    list={[
+      ["HOME", "/"],
+      ["TERRARIUMS", "/terrariums"],
+      ["HOW-TO", "/instructions"],
+      ["CONTACTS", "/contacts"],
+      ["GitHub", "/dev"],
+    ]}
+  />
+);

--- a/.design-sync/previews/Inline.tsx
+++ b/.design-sync/previews/Inline.tsx
@@ -1,0 +1,17 @@
+import { Inline, Button, Body } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const Buttons = () => (
+  <Inline space={16} alignY="center">
+    <Button label="SEND" kind="solid" onPress={noop} />
+    <Button label="CANCEL" kind="transparent" onPress={noop} />
+  </Inline>
+);
+
+export const Centered = () => (
+  <Inline space={8} alignY="center" align="center">
+    <Body size="medium">👉</Body>
+    <Button label="This website GitHub repo" kind="transparent" size="large" onPress={noop} />
+  </Inline>
+);

--- a/.design-sync/previews/Link.tsx
+++ b/.design-sync/previews/Link.tsx
@@ -1,0 +1,9 @@
+import { Link, Body } from "@gorlium/design-system";
+
+export const Default = () => <Link href="https://github.com/GorlemZ/gorlium">This website GitHub repo</Link>;
+
+export const Inline = () => (
+  <Body size="medium">
+    Check out the <Link href="#">source code</Link> and open an issue if you find a bug.
+  </Body>
+);

--- a/.design-sync/previews/PostSection.tsx
+++ b/.design-sync/previews/PostSection.tsx
@@ -1,0 +1,36 @@
+import { PostSection } from "@gorlium/design-system";
+
+const IMG =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='480' height='360'%3E%3Crect width='100%25' height='100%25' fill='%231c1c1c'/%3E%3Crect x='10' y='10' width='460' height='340' fill='none' stroke='%23c9f24d' stroke-width='4'/%3E%3Ctext x='50%25' y='50%25' fill='%23c9f24d' font-family='monospace' font-size='30' text-anchor='middle' dominant-baseline='middle'%3ETERRARIUM%3C/text%3E%3C/svg%3E";
+
+export const TextOnly = () => (
+  <PostSection
+    title="20 Jan 2025 — Not yet started, already changed"
+    text={[
+      "SO. Here I am, trying my best to develop this website.",
+      "What started as a simple frontend exercise has somehow morphed into the hub for all my hobbies. 🤷",
+    ]}
+  />
+);
+
+export const WithImage = () => (
+  <PostSection
+    title="The right mixture"
+    imgPath={IMG}
+    imgSize="1/2"
+    text={[
+      "The first time I made a terrarium, I failed spectacularly 🥀.",
+      "Terrariums, I learned, are about balance — and soil is at the heart of that.",
+    ]}
+  />
+);
+
+export const ImageRight = () => (
+  <PostSection
+    title="The tiny world"
+    imgPath={IMG}
+    imgSize="1/2"
+    imgAlignRight
+    text={["Those tiny jars of greenery are like a whole world in miniature."]}
+  />
+);

--- a/.design-sync/previews/Stack.tsx
+++ b/.design-sync/previews/Stack.tsx
@@ -1,0 +1,24 @@
+import { Stack, Title, Body } from "@gorlium/design-system";
+
+export const Spaced = () => (
+  <Stack space={16}>
+    <Title size="small">The tiny world</Title>
+    <Body size="medium">Those tiny jars of greenery are like a whole world in miniature.</Body>
+    <Body size="medium">They're always a hit as gifts.</Body>
+  </Stack>
+);
+
+export const WithDividers = () => (
+  <Stack space={24} dividers>
+    <Body size="medium">Attempt One lasted three weeks.</Body>
+    <Body size="medium">Attempt Two failed almost immediately.</Body>
+    <Body size="medium">Attempt Three thrived for five years.</Body>
+  </Stack>
+);
+
+export const Centered = () => (
+  <Stack space={12} align="center">
+    <Title size="medium">GORLIUM</Title>
+    <Body size="small">A tiny self-contained ecosystem.</Body>
+  </Stack>
+);

--- a/.design-sync/previews/TextArea.tsx
+++ b/.design-sync/previews/TextArea.tsx
@@ -1,0 +1,17 @@
+import { TextArea } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const Filled = () => (
+  <TextArea
+    name="message"
+    label="Message"
+    rows={5}
+    value={"Hi! I'd love a terrarium for my office window.\nDo you ship?"}
+    onChange={noop}
+  />
+);
+
+export const WithPlaceholder = () => (
+  <TextArea name="message" label="Message" placeholder="Type your message here..." rows={5} value="" onChange={noop} />
+);

--- a/.design-sync/previews/TextField.tsx
+++ b/.design-sync/previews/TextField.tsx
@@ -1,0 +1,11 @@
+import { TextField } from "@gorlium/design-system";
+
+const noop = () => {};
+
+export const Filled = () => (
+  <TextField name="name" label="Name" value="Patrizio" onChange={noop} />
+);
+
+export const WithPlaceholder = () => (
+  <TextField name="name" label="Name" placeholder="Type your name here..." value="" onChange={noop} />
+);

--- a/.design-sync/previews/Tiles.tsx
+++ b/.design-sync/previews/Tiles.tsx
@@ -1,0 +1,27 @@
+import { Tiles, Box, Body } from "@gorlium/design-system";
+
+const tile = (n: number) => (
+  <Box padding={20} style={{ background: "var(--g-surface)", border: "2px solid var(--g-border)" }}>
+    <Body size="small">Tile {n}</Body>
+  </Box>
+);
+
+export const ThreeColumns = () => (
+  <Tiles space={16} columns={3}>
+    {tile(1)}
+    {tile(2)}
+    {tile(3)}
+    {tile(4)}
+    {tile(5)}
+    {tile(6)}
+  </Tiles>
+);
+
+export const TwoColumns = () => (
+  <Tiles space={12} columns={2}>
+    {tile(1)}
+    {tile(2)}
+    {tile(3)}
+    {tile(4)}
+  </Tiles>
+);

--- a/.design-sync/previews/Title.tsx
+++ b/.design-sync/previews/Title.tsx
@@ -1,0 +1,17 @@
+import { Title, Stack } from "@gorlium/design-system";
+
+export const Sizes = () => (
+  <Stack space={16}>
+    <Title size="large">GORLIUM</Title>
+    <Title size="medium">The right mixture</Title>
+    <Title size="small">22 Jan 2025 — Deployin</Title>
+  </Stack>
+);
+
+export const Large = () => <Title size="large">WELCOME TO THE GORLIUM</Title>;
+
+export const Centered = () => (
+  <Title size="medium" align="center">
+    A tiny world
+  </Title>
+);

--- a/.design-sync/previews/WeirdFlex.tsx
+++ b/.design-sync/previews/WeirdFlex.tsx
@@ -1,0 +1,16 @@
+import { WeirdFlex, Box, Body } from "@gorlium/design-system";
+
+const item = (label: string) => (
+  <Box padding={16} style={{ background: "var(--g-surface)", border: "2px solid var(--g-border)", width: 200 }}>
+    <Body size="small">{label}</Body>
+  </Box>
+);
+
+// Centered column flex that collapses to a row on narrow screens.
+export const Stacked = () => (
+  <WeirdFlex gap={16}>
+    {item("First")}
+    {item("Second")}
+    {item("Third")}
+  </WeirdFlex>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ dist-ssr
 
 # Local Netlify folder
 .netlify
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Syncs `@gorlium/design-system` to the Claude Design project **Gorlium** (`8e91b7c6-753a-4a54-bf34-cbb9a1662cd5`).

Adds only the durable sync inputs (regenerated build output stays gitignored):
- `.design-sync/config.json` — package shape, provider (`GorliumProvider`), CSS entry, build cmd
- `.design-sync/conventions.md` — conventions header for the Claude Design agent (provider wrap, `.g-*` idiom, `--g-*` tokens)
- `.design-sync/NOTES.md` — repo gotchas + re-sync watch-list
- `.gitignore` — ignore staged converter scripts and build output

First sync was minimal (20 components as floor cards; render check skipped). One-way sync: repo → Claude Design component library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)