### PR TITLE
fix(contacts): real Telegram send feedback + full-screen layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ ds-bundle/
 
 # Claude Code local settings (personal, incl. permission mode)
 .claude/settings.local.json
+.claude/launch.json

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -1,0 +1,9 @@
+# Telegram contact form — required for the /contacts page to deliver messages.
+# These are read at BUILD time by Vite (import.meta.env.VITE_*), so they must be
+# set both locally (.env) and in the Netlify build environment, then re-deployed.
+#
+# Local: copy this file to packages/app/.env and fill in real values.
+# Netlify: Site settings → Environment variables → add the two VITE_ vars below.
+
+VITE_TELEGRAM_BOT_TOKEN=123456789:your-bot-token-here
+VITE_TELEGRAM_CHAT_ID=your-chat-id-here

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -12,6 +12,7 @@
       "formDescription": "Write me a message 💌 and remember to leave your contact info",
       "formTitle": "Do you want a terrarium?",
       "errorMessage": "Please fill in all the fields 🥲",
+      "sendError": "Sending failed, please try again later 😢",
       "successMessage": "SENT! 🌵🌵🌵",
       "formMessage": "Message",
       "formName": "Name",

--- a/packages/app/src/locales/it.json
+++ b/packages/app/src/locales/it.json
@@ -12,6 +12,7 @@
       "formDescription": "Scrivimi un messaggio 💌 e ricordati di lasciare le tue informazioni di contatto",
       "formTitle": "Vuoi un terrario?",
       "errorMessage": "Per favore, compila tutti i campi 🥲",
+      "sendError": "Invio non riuscito, riprova più tardi 😢",
       "successMessage": "INVIATO! 🌵🌵🌵",
       "formMessage": "Messaggio",
       "formName": "Nome",

--- a/packages/app/src/pages/Contacts.tsx
+++ b/packages/app/src/pages/Contacts.tsx
@@ -9,30 +9,34 @@ import {
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-const sendMessageToTelegram = async (message: string) => {
+const sendMessageToTelegram = async (message: string): Promise<boolean> => {
   const telegramToken = import.meta.env.VITE_TELEGRAM_BOT_TOKEN;
   const chatId = import.meta.env.VITE_TELEGRAM_CHAT_ID;
+
+  if (!telegramToken || !chatId) {
+    console.error(
+      "Telegram is not configured: set VITE_TELEGRAM_BOT_TOKEN and VITE_TELEGRAM_CHAT_ID at build time."
+    );
+    return false;
+  }
+
   const url = `https://api.telegram.org/bot${telegramToken}/sendMessage?chat_id=${chatId}&text=${encodeURIComponent(
     message
   )}`;
 
   try {
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    const response = await fetch(url, { method: "GET" });
+    const data = await response.json().catch(() => null);
 
-    if (!response.ok) {
-      console.error(`HTTP error! status: ${response.status}`);
+    if (!response.ok || !data?.ok) {
+      console.error("Telegram API error:", response.status, data);
+      return false;
     }
 
-    const data = await response.json();
-    return data;
+    return true;
   } catch (error) {
     console.error("Error sending message:", error);
-    throw error;
+    return false;
   }
 };
 
@@ -44,16 +48,27 @@ function Contacts() {
   const [error, setError] = React.useState("");
 
   const onSubmit = async () => {
-    if (name !== "" && message !== "") {
-      setIsSent(true);
-      sendMessageToTelegram(`FROM: ${name}\nMESSAGE:\n ${message}`);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      setMessage("");
-      setName("");
-      setIsSent(false);
-    } else {
+    setError("");
+
+    if (name === "" || message === "") {
       setError(t("contacts.errorMessage"));
+      return;
     }
+
+    const delivered = await sendMessageToTelegram(
+      `FROM: ${name}\nMESSAGE:\n ${message}`
+    );
+
+    if (!delivered) {
+      setError(t("contacts.sendError"));
+      return;
+    }
+
+    setIsSent(true);
+    setMessage("");
+    setName("");
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    setIsSent(false);
   };
   return (
     <Stack space={0} dividers={true} align={"center"}>
@@ -85,7 +100,7 @@ function Contacts() {
             label={t("contacts.formMessage")}
             value={message}
             onChange={setMessage}
-            rows={10}
+            rows={4}
           />
         </FormSection>
       </Form>


### PR DESCRIPTION
## Contesto
La pagina contatti aveva due problemi:
1. **Layout**: il form era più alto del viewport e costringeva a scrollare.
2. **Invio Telegram**: i messaggi non arrivavano e il form mostrava comunque "INVIATO!". Causa principale = env var `VITE_TELEGRAM_*` non impostate al build Netlify (token cablato come `botundefined`); causa secondaria = la `fetch` non era awaited e gli errori venivano ingoiati → falso successo.

## Modifiche
- **Layout full-screen**: `TextArea` del messaggio da `rows={10}` a `rows={4}` → la pagina sta in una schermata (verificato: `scrollHeight == innerHeight`).
- **Esito reale invio**: `sendMessageToTelegram` ritorna un `boolean` (controlla `response.ok` **e** `data.ok` di Telegram) e fa un guard esplicito se le env var mancano.
- **onSubmit awaited**: mostra successo solo a consegna confermata, altrimenti errore reale e mantiene i campi per il retry.
- Nuova chiave i18n `contacts.sendError` (it/en).
- `packages/app/.env.example` che documenta `VITE_TELEGRAM_BOT_TOKEN` / `VITE_TELEGRAM_CHAT_ID`.
- `.gitignore`: ignora `.claude/launch.json`.

## Verifica
- Preview locale: invio→errore reale (no falso successo); campi vuoti→errore validazione; CORS verso api.telegram.org OK.
- `tsc -b` exit 0.

## ⚠️ Azione richiesta (non in questa PR)
Per far arrivare davvero i messaggi: impostare `VITE_TELEGRAM_BOT_TOKEN` e `VITE_TELEGRAM_CHAT_ID` nelle **Environment variables di Netlify** e fare un **nuovo deploy** (le var `VITE_` sono cablate al build).

Nota sicurezza: con questo approccio il token resta pubblico nel bundle; la soluzione robusta (Netlify Function proxy) è stata rimandata su scelta dell'utente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)