### PR TITLE
feat(hub): top-level homepage hub + nest terrarium area under /terrariums

### DIFF
--- a/packages/app/i18n.ts
+++ b/packages/app/i18n.ts
@@ -31,8 +31,8 @@ export const resources = {
 
 i18n.use(initReactI18next).init({
   resources, // Use only the predefined resources
-  lng: "it",
-  fallbackLng: "it",
+  lng: "en",
+  fallbackLng: "en",
   debug: true,
   interpolation: {
     escapeValue: false,

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -10,8 +10,14 @@
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
+    <script>
+      // Paint the right background before React mounts: the hub (/) is light,
+      // the terrarium area is dark. Avoids a flash of the wrong colour.
+      document.documentElement.style.backgroundColor =
+        location.pathname === "/" ? "#e4ded1" : "#0e1410";
+    </script>
   </head>
-  <body style="background-color: #0e1410">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gorlium</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Space+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body style="background-color: #0e1410">
     <div id="root"></div>

--- a/packages/app/public/_redirects
+++ b/packages/app/public/_redirects
@@ -1,1 +1,7 @@
+# Old flat URLs -> new nested terrarium-area paths (must precede the SPA catch-all)
+/instructions   /terrariums/how-to     301
+/contacts       /terrariums/contacts   301
+/dev            /terrariums/dev        301
+
+# SPA fallback
 /*    /index.html   200

--- a/packages/app/public/gorlium/gioielleria.svg
+++ b/packages/app/public/gorlium/gioielleria.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#cda64e" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#18130c"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#cda64e" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#cda64e" opacity="0.9">GIOIELLERIA</text>
+</svg>

--- a/packages/app/public/gorlium/maglia.svg
+++ b/packages/app/public/gorlium/maglia.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#cc7a4f" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#2a1611"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#cc7a4f" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#cc7a4f" opacity="0.9">MAGLIA</text>
+</svg>

--- a/packages/app/public/gorlium/mente.svg
+++ b/packages/app/public/gorlium/mente.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#9b8cc4" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#20202e"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#9b8cc4" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#9b8cc4" opacity="0.9">MENTE</text>
+</svg>

--- a/packages/app/public/gorlium/sartoria.svg
+++ b/packages/app/public/gorlium/sartoria.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#aab6d2" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#1a2130"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#aab6d2" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#aab6d2" opacity="0.9">SARTORIA</text>
+</svg>

--- a/packages/app/public/gorlium/software.svg
+++ b/packages/app/public/gorlium/software.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#5fb3c6" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#0f161d"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#5fb3c6" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#5fb3c6" opacity="0.9">SOFTWARE</text>
+</svg>

--- a/packages/app/public/gorlium/terrari.svg
+++ b/packages/app/public/gorlium/terrari.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="236" viewBox="0 0 320 236">
+  <defs>
+    <pattern id="p" width="26" height="26" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="13" height="26" fill="#8faa57" opacity="0.14"></rect>
+    </pattern>
+  </defs>
+  <rect width="320" height="236" fill="#1b2a1e"></rect>
+  <rect width="320" height="236" fill="url(#p)"></rect>
+  <rect x="8" y="8" width="304" height="220" fill="none" stroke="#8faa57" stroke-width="2" opacity="0.5"></rect>
+  <text x="20" y="216" font-family="&#39;Space Mono&#39;, monospace" font-size="17" letter-spacing="2" fill="#8faa57" opacity="0.9">TERRARI</text>
+</svg>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,32 +1,78 @@
-import {
-  Header,
-  Banner,
-  Title,
-  Inline,
-  Stack,
-} from "@gorlium/design-system";
+import { Header, Banner, Title, Stack } from "@gorlium/design-system";
+import { Route, BrowserRouter, Routes, Outlet, Link } from "react-router-dom";
+import Hub from "./pages/Hub";
 import Homepage from "./pages/Homepage";
-import { Route, BrowserRouter, Routes } from "react-router-dom";
-import Lore from "./pages/Lore";
 import Terrariums from "./pages/Terrariums";
 import Dev from "./pages/Dev";
 import Contacts from "./pages/Contacts";
 import i18n from "../i18n";
 import { useTranslation } from "react-i18next";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { Instructions } from "./pages/Instructions";
 
-function App() {
-  // const [isEng, setIsEng] = useState(() => {
-  //   const savedLang = localStorage.getItem("language");
-  //   return savedLang ? savedLang === "en" : false;
-  // });
+// The terrarium area keeps the original digital-brutalism chrome (Header +
+// Banner). Other hub worlds will get their own layouts as they're built.
+function TerrariumLayout() {
+  const { t } = useTranslation();
 
   const handleLanguageChange = () => {
     // Temporarily disable language switching
     console.log("Language switching is disabled.");
   };
 
+  return (
+    <div style={{ maxWidth: "1400px", margin: "0 auto", overflow: "hidden" }}>
+      <Stack
+        space={16}
+        align={{
+          mobile: "center",
+          tablet: "center",
+          desktop: "center",
+          wide: "center",
+        }}
+      >
+        <Link
+          to="/"
+          style={{
+            alignSelf: "flex-start",
+            margin: "8px 0 0 8px",
+            font: "700 11px/1 'Space Mono', monospace",
+            letterSpacing: ".16em",
+            color: "inherit",
+            textDecoration: "none",
+            opacity: 0.7,
+          }}
+        >
+          ← GORLIUM HUB
+        </Link>
+        <Header
+          onToggleLanguage={handleLanguageChange}
+          initialLanguage={"it"}
+          list={[
+            [t("header.home"), "/terrariums"],
+            [t("header.terrariums"), "/terrariums/gallery"],
+            [t("header.instructions"), "/terrariums/how-to"],
+            [t("header.contacts"), "/terrariums/contacts"],
+            [t("header.dev"), "/terrariums/dev"],
+          ]}
+        />
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+          }}
+        >
+          <Outlet />
+        </div>
+        <Banner>
+          <Title size={"medium"}>{t("bannerWelcome")}</Title>
+        </Banner>
+      </Stack>
+    </div>
+  );
+}
+
+function App() {
   useEffect(() => {
     const savedLang = localStorage.getItem("language");
     if (savedLang) {
@@ -34,50 +80,18 @@ function App() {
     }
   }, []);
 
-  const { t } = useTranslation();
-
   return (
     <BrowserRouter>
-      <div style={{ maxWidth: "1400px", margin: "0 auto", overflow: "hidden" }}>
-        <Stack
-          space={16}
-          align={{
-            mobile: "center",
-            tablet: "center",
-            desktop: "center",
-            wide: "center",
-          }}
-        >
-          <Header
-            onToggleLanguage={handleLanguageChange}
-            initialLanguage={"it"}
-            list={[
-              [t("header.home"), "/"],
-              [t("header.terrariums"), "terrariums"],
-              [t("header.instructions"), "instructions"],
-              [t("header.contacts"), "contacts"],
-              [t("header.dev"), "dev"],
-            ]}
-          />
-          <div
-            style={{
-              height: "100%",
-              width: "100%",
-            }}
-          >
-            <Routes>
-              <Route path="/" element={<Homepage />} />
-              <Route path="/instructions" element={<Instructions />} />
-              <Route path="/terrariums" element={<Terrariums />} />
-              <Route path="/dev" element={<Dev />} />
-              <Route path="/contacts" element={<Contacts />} />
-            </Routes>
-          </div>
-          <Banner>
-            <Title size={"medium"}>{t("bannerWelcome")}</Title>
-          </Banner>
-        </Stack>
-      </div>
+      <Routes>
+        <Route path="/" element={<Hub />} />
+        <Route path="/terrariums" element={<TerrariumLayout />}>
+          <Route index element={<Homepage />} />
+          <Route path="gallery" element={<Terrariums />} />
+          <Route path="how-to" element={<Instructions />} />
+          <Route path="contacts" element={<Contacts />} />
+          <Route path="dev" element={<Dev />} />
+        </Route>
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -97,15 +97,24 @@
       "title": "How to take care of your terrarium 🌱",
       "step1": {
         "title": "Where to place it",
-        "content": "Put your terrarium in a bright spot, but avoid direct sunlight. Sun rays can overheat the glass and damage the plants. Indirect, diffused light is best."
+        "content": [
+          "Put your terrarium in a bright spot, but avoid direct sunlight. Sun rays can overheat the glass and damage the plants. Indirect, diffused light is best."
+        ]
       },
       "step2": {
         "title": "Checking condensation",
-        "content": "Take a look at the glass every now and then:\n\nCondensation up to half of the glass → perfect conditions ✅\n\nNo condensation → the terrarium is too dry. Spray 2–3 times with a mister and repeat daily until you see the right amount of condensation.\n\nCondensation covering most of the glass → the terrarium is too humid. Leave the lid slightly open for about 10 minutes a day and repeat until humidity is balanced again."
+        "content": [
+          "Take a look at the glass every now and then:",
+          "Condensation up to half of the glass → perfect conditions ✅",
+          "No condensation → the terrarium is too dry. Spray 2–3 times with a mister and repeat daily until you see the right amount of condensation.",
+          "Condensation covering most of the glass → the terrarium is too humid. Leave the lid slightly open for about 10 minutes a day and repeat until humidity is balanced again."
+        ]
       },
       "step3": {
         "title": "Minimal maintenance",
-        "content": "If you bought a terrarium from me, you won’t need to worry too much: my terrariums are already “stabilized” and require very little care. Just check the condensation once in a while and intervene only if needed."
+        "content": [
+          "If you bought a terrarium from me, you won’t need to worry too much: my terrariums are already “stabilized” and require very little care. Just check the condensation once in a while and intervene only if needed."
+        ]
       }
     }
   }

--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Gorlium — homepage hub.
@@ -8,8 +8,10 @@ import { useLayoutEffect, useRef, useState } from "react";
  * dependency on the terrarium-area design system. Ported from the Claude
  * Design handoff (personal-interest-hub-design / gorlium.dc.html).
  *
- * Only enabled worlds navigate on click; the rest still reveal their preview
- * on hover but are not clickable yet.
+ * Desktop keeps the original hover layout (decentred list + bleeding giant
+ * title + floating preview). On narrow screens hover doesn't exist and the
+ * absolute positioning overlaps, so we render a simple stacked, always-on list
+ * instead. Only enabled worlds navigate on click.
  */
 
 const INK = "#15140f";
@@ -18,6 +20,8 @@ const BG = "#e4ded1";
 
 const mono = "'Space Mono', monospace";
 const sans = "'Archivo', system-ui, sans-serif";
+
+const MOBILE_BREAKPOINT = 760;
 
 interface World {
   slug: string;
@@ -38,15 +42,32 @@ const WORLDS: World[] = [
   { slug: "mente", name: "Mental Health", accent: "#9b8cc4", desc: "A space to slow down.", img: "/gorlium/mente.svg", href: null, restricted: true },
 ];
 
+const RESTRICTED_BADGE = (
+  <span style={{ font: `700 8px/1 ${mono}`, letterSpacing: ".12em", border: "1px solid currentColor", padding: "4px 5px", opacity: 0.7, whiteSpace: "nowrap" }}>RESTRICTED</span>
+);
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT
+  );
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return isMobile;
+}
+
 function Hub() {
+  const isMobile = useIsMobile();
   const [active, setActive] = useState<number | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLElement | null)[]>([]);
   const [rowCenter, setRowCenter] = useState(0);
 
-  // Position the giant title + preview at the centre of the active row.
+  // Position the giant title + preview at the centre of the active row (desktop only).
   useLayoutEffect(() => {
-    if (active == null) return;
+    if (isMobile || active == null) return;
     const reposition = () => {
       const content = contentRef.current;
       const it = itemRefs.current[active];
@@ -63,116 +84,152 @@ function Hub() {
       clearTimeout(t);
       window.removeEventListener("resize", reposition);
     };
-  }, [active]);
+  }, [active, isMobile]);
 
   const cur = active != null ? WORLDS[active] : null;
   const giantTone = cur ? cur.accent : INK;
 
   return (
-    <div style={{ position: "relative", width: "100%", background: BG, padding: 14, minHeight: "100vh", boxSizing: "border-box", fontFamily: sans }}>
+    <div style={{ position: "relative", width: "100%", background: BG, padding: isMobile ? 8 : 14, minHeight: "100vh", boxSizing: "border-box", fontFamily: sans }}>
       <div
-        onMouseLeave={() => setActive(null)}
-        style={{ position: "relative", border: `1.5px solid ${INK}`, background: PAPER, minHeight: "calc(100vh - 28px)", overflow: "hidden", display: "flex", flexDirection: "column" }}
+        onMouseLeave={() => !isMobile && setActive(null)}
+        style={{ position: "relative", border: `1.5px solid ${INK}`, background: PAPER, minHeight: isMobile ? "calc(100vh - 16px)" : "calc(100vh - 28px)", overflow: "hidden", display: "flex", flexDirection: "column" }}
       >
-        {/* decorative rotated labels */}
-        <div style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%) rotate(-90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>© MMXXVI</div>
-        <div style={{ position: "absolute", right: 12, top: "50%", transform: "translateY(-50%) rotate(90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>HANDMADE — ITALY</div>
+        {/* decorative rotated labels — desktop only (they overlap on narrow screens) */}
+        {!isMobile && (
+          <>
+            <div style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%) rotate(-90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>© MMXXVI</div>
+            <div style={{ position: "absolute", right: 12, top: "50%", transform: "translateY(-50%) rotate(90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>HANDMADE — ITALY</div>
+          </>
+        )}
 
         {/* masthead */}
-        <header style={{ position: "relative", zIndex: 20, padding: "34px clamp(28px,5vw,64px) 0" }}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", font: `700 12px/1.5 ${mono}`, letterSpacing: ".16em", color: INK }}>
+        <header style={{ position: "relative", zIndex: 20, padding: isMobile ? "22px clamp(18px,6vw,28px) 0" : "34px clamp(28px,5vw,64px) 0" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", font: `700 ${isMobile ? 10 : 12}px/1.5 ${mono}`, letterSpacing: ".16em", color: INK }}>
             <span>GORLIUM</span>
             <span style={{ opacity: 0.55 }}>HUB OF WORLDS</span>
           </div>
           <div style={{ font: `900 clamp(54px,11vw,150px)/.86 ${sans}`, letterSpacing: "-.035em", color: INK, marginTop: 18 }}>gorlium</div>
         </header>
 
-        {/* content */}
-        <div ref={contentRef} style={{ position: "relative", flex: 1, minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
-          {/* preview: image + description, tracks the active row */}
-          <div
-            style={{
-              position: "absolute", left: 0, width: 300, zIndex: 16,
-              top: rowCenter, transform: "translateY(-50%)",
-              opacity: cur ? 1 : 0, pointerEvents: "none",
-              display: "flex", gap: 18, alignItems: "flex-start",
-            }}
-          >
-            {cur && (
-              <>
-                <img src={cur.img} alt="" style={{ width: 150, height: 112, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}` }} />
-                <div style={{ font: `400 14px/1.45 ${mono}`, color: INK, maxWidth: 140 }}>
-                  {cur.desc}
-                  {cur.restricted && <span style={{ opacity: 0.55 }}> — restricted area.</span>}
-                </div>
-              </>
-            )}
+        {isMobile ? (
+          /* ---------- mobile: stacked, always-on list ---------- */
+          <div style={{ position: "relative", zIndex: 18, flex: 1, padding: "28px clamp(18px,6vw,28px) 8px" }}>
+            <div style={{ font: `800 14px/1 ${sans}`, letterSpacing: ".02em", color: INK, marginBottom: 22, textTransform: "uppercase", opacity: 0.7 }}>My worlds</div>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {WORLDS.map((it) => {
+                const enabled = it.href != null;
+                const rowStyle: React.CSSProperties = {
+                  display: "flex", alignItems: "center", gap: 14, padding: "14px 0", color: INK,
+                  textDecoration: "none", borderTop: `1px solid ${INK}22`,
+                  opacity: enabled ? 1 : 0.6, cursor: enabled ? "pointer" : "default",
+                };
+                const inner = (
+                  <>
+                    <img src={it.img} alt="" style={{ width: 64, height: 48, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}`, borderLeft: `4px solid ${it.accent}` }} />
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                        <span style={{ font: `700 21px/1.05 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
+                        {it.restricted && RESTRICTED_BADGE}
+                      </div>
+                      <div style={{ font: `400 12px/1.4 ${mono}`, color: INK, opacity: 0.7, marginTop: 4 }}>{it.desc}</div>
+                    </div>
+                  </>
+                );
+                return enabled ? (
+                  <a key={it.slug} href={it.href as string} style={rowStyle}>{inner}</a>
+                ) : (
+                  <div key={it.slug} aria-disabled="true" style={rowStyle}>{inner}</div>
+                );
+              })}
+            </div>
           </div>
-
-          {/* giant bleeding name behind the list, tracks the active row */}
-          <div
-            style={{
-              position: "absolute", left: "calc(54% + 120px)", font: `800 clamp(52px,8vw,132px)/.84 ${sans}`,
-              letterSpacing: "-.035em", whiteSpace: "nowrap", color: giantTone, zIndex: 4, pointerEvents: "none",
-              top: rowCenter, transform: "translateY(-50%)", opacity: cur ? 0.42 : 0,
-            }}
-          >
-            {cur ? cur.name : ""}
-          </div>
-
-          {/* decentered list */}
-          <div style={{ position: "absolute", left: "54%", top: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
-            <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
-
-            {WORLDS.map((it, i) => {
-              const on = active === i;
-              const enabled = it.href != null;
-              const sharedStyle: React.CSSProperties = {
-                display: "flex", alignItems: "center", gap: 12, padding: "15px 0", color: INK,
-                cursor: enabled ? "pointer" : "default", textDecoration: "none",
-                transform: on ? "translateX(16px)" : "translateX(0)",
-                transition: "transform .18s ease",
-                opacity: enabled ? 1 : 0.62,
-              };
-              const inner = (
+        ) : (
+          /* ---------- desktop: decentred list + hover preview ---------- */
+          <div ref={contentRef} style={{ position: "relative", flex: 1, minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
+            {/* preview: image + description, tracks the active row */}
+            <div
+              style={{
+                position: "absolute", left: 0, width: 300, zIndex: 16,
+                top: rowCenter, transform: "translateY(-50%)",
+                opacity: cur ? 1 : 0, pointerEvents: "none",
+                display: "flex", gap: 18, alignItems: "flex-start",
+              }}
+            >
+              {cur && (
                 <>
-                  <span style={{ opacity: on ? 1 : 0, font: `400 20px/1 ${sans}`, marginLeft: -26, width: 14 }}>•</span>
-                  <span style={{ font: `${on ? 800 : 500} clamp(24px,2.4vw,31px)/1 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
-                  {it.restricted && (
-                    <span style={{ font: `700 8px/1 ${mono}`, letterSpacing: ".12em", border: "1px solid currentColor", padding: "4px 5px", opacity: 0.7, whiteSpace: "nowrap" }}>RESTRICTED</span>
-                  )}
+                  <img src={cur.img} alt="" style={{ width: 150, height: 112, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}` }} />
+                  <div style={{ font: `400 14px/1.45 ${mono}`, color: INK, maxWidth: 140 }}>
+                    {cur.desc}
+                    {cur.restricted && <span style={{ opacity: 0.55 }}> — restricted area.</span>}
+                  </div>
                 </>
-              );
-              const setRef = (el: HTMLElement | null) => {
-                itemRefs.current[i] = el;
-              };
-              return enabled ? (
-                <a
-                  key={it.slug}
-                  href={it.href as string}
-                  ref={setRef}
-                  onMouseEnter={() => setActive(i)}
-                  style={sharedStyle}
-                >
-                  {inner}
-                </a>
-              ) : (
-                <div
-                  key={it.slug}
-                  ref={setRef}
-                  onMouseEnter={() => setActive(i)}
-                  aria-disabled="true"
-                  style={sharedStyle}
-                >
-                  {inner}
-                </div>
-              );
-            })}
+              )}
+            </div>
+
+            {/* giant bleeding name behind the list, tracks the active row */}
+            <div
+              style={{
+                position: "absolute", left: "calc(54% + 120px)", font: `800 clamp(52px,8vw,132px)/.84 ${sans}`,
+                letterSpacing: "-.035em", whiteSpace: "nowrap", color: giantTone, zIndex: 4, pointerEvents: "none",
+                top: rowCenter, transform: "translateY(-50%)", opacity: cur ? 0.42 : 0,
+              }}
+            >
+              {cur ? cur.name : ""}
+            </div>
+
+            {/* decentered list */}
+            <div style={{ position: "absolute", left: "54%", top: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
+              <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
+
+              {WORLDS.map((it, i) => {
+                const on = active === i;
+                const enabled = it.href != null;
+                const sharedStyle: React.CSSProperties = {
+                  display: "flex", alignItems: "center", gap: 12, padding: "15px 0", color: INK,
+                  cursor: enabled ? "pointer" : "default", textDecoration: "none",
+                  transform: on ? "translateX(16px)" : "translateX(0)",
+                  transition: "transform .18s ease",
+                  opacity: enabled ? 1 : 0.62,
+                };
+                const inner = (
+                  <>
+                    <span style={{ opacity: on ? 1 : 0, font: `400 20px/1 ${sans}`, marginLeft: -26, width: 14 }}>•</span>
+                    <span style={{ font: `${on ? 800 : 500} clamp(24px,2.4vw,31px)/1 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
+                    {it.restricted && RESTRICTED_BADGE}
+                  </>
+                );
+                const setRef = (el: HTMLElement | null) => {
+                  itemRefs.current[i] = el;
+                };
+                return enabled ? (
+                  <a
+                    key={it.slug}
+                    href={it.href as string}
+                    ref={setRef}
+                    onMouseEnter={() => setActive(i)}
+                    style={sharedStyle}
+                  >
+                    {inner}
+                  </a>
+                ) : (
+                  <div
+                    key={it.slug}
+                    ref={setRef}
+                    onMouseEnter={() => setActive(i)}
+                    aria-disabled="true"
+                    style={sharedStyle}
+                  >
+                    {inner}
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* footer */}
-        <div style={{ position: "relative", zIndex: 20, display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `1.5px solid ${INK}`, margin: "0 clamp(28px,5vw,64px)", padding: "16px 0 28px", font: `700 11px/1 ${mono}`, letterSpacing: ".16em", color: INK }}>
+        <div style={{ position: "relative", zIndex: 20, display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `1.5px solid ${INK}`, margin: isMobile ? "0 clamp(18px,6vw,28px)" : "0 clamp(28px,5vw,64px)", padding: isMobile ? "14px 0 18px" : "16px 0 28px", font: `700 11px/1 ${mono}`, letterSpacing: ".16em", color: INK }}>
           <span>© GORLIUM</span>
           <span style={{ opacity: 0.55 }}>SIX WORLDS</span>
         </div>

--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -1,0 +1,184 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Gorlium — homepage hub.
+ *
+ * Top-level landing that links out to the thematic "worlds". Intentionally
+ * self-contained: its own typography (Archivo + Space Mono) and palette, no
+ * dependency on the terrarium-area design system. Ported from the Claude
+ * Design handoff (personal-interest-hub-design / gorlium.dc.html).
+ *
+ * Only enabled worlds navigate on click; the rest still reveal their preview
+ * on hover but are not clickable yet.
+ */
+
+const INK = "#15140f";
+const PAPER = "#ece7dd";
+const BG = "#e4ded1";
+
+const mono = "'Space Mono', monospace";
+const sans = "'Archivo', system-ui, sans-serif";
+
+interface World {
+  slug: string;
+  name: string;
+  accent: string;
+  desc: string;
+  img: string;
+  href: string | null;
+  restricted: boolean;
+}
+
+const WORLDS: World[] = [
+  { slug: "terrari", name: "Terrariums", accent: "#8faa57", desc: "Tiny worlds, sealed under glass.", img: "/gorlium/terrari.svg", href: "/terrariums", restricted: false },
+  { slug: "sartoria", name: "Tailoring", accent: "#8aa0c8", desc: "Made-to-measure, from the pattern.", img: "/gorlium/sartoria.svg", href: null, restricted: false },
+  { slug: "gioielleria", name: "Jewelry", accent: "#cda64e", desc: "Metal and stone, in the detail.", img: "/gorlium/gioielleria.svg", href: null, restricted: false },
+  { slug: "maglia", name: "Knitting & Crochet", accent: "#cc7a4f", desc: "Handmade, warm and slow.", img: "/gorlium/maglia.svg", href: null, restricted: false },
+  { slug: "software", name: "Software & Development", accent: "#5fb3c6", desc: "Code, systems and experiments.", img: "/gorlium/software.svg", href: null, restricted: false },
+  { slug: "mente", name: "Mental Health", accent: "#9b8cc4", desc: "A space to slow down.", img: "/gorlium/mente.svg", href: null, restricted: true },
+];
+
+function Hub() {
+  const [active, setActive] = useState<number | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLElement | null)[]>([]);
+  const [rowCenter, setRowCenter] = useState(0);
+
+  // Position the giant title + preview at the centre of the active row.
+  useLayoutEffect(() => {
+    if (active == null) return;
+    const reposition = () => {
+      const content = contentRef.current;
+      const it = itemRefs.current[active];
+      if (!content || !it) return;
+      const cr = content.getBoundingClientRect();
+      const ir = it.getBoundingClientRect();
+      setRowCenter(ir.top - cr.top + ir.height / 2);
+    };
+    reposition();
+    const t = setTimeout(reposition, 350);
+    window.addEventListener("resize", reposition);
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(reposition);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [active]);
+
+  const cur = active != null ? WORLDS[active] : null;
+  const giantTone = cur ? cur.accent : INK;
+
+  return (
+    <div style={{ position: "relative", width: "100%", background: BG, padding: 14, minHeight: "100vh", boxSizing: "border-box", fontFamily: sans }}>
+      <div
+        onMouseLeave={() => setActive(null)}
+        style={{ position: "relative", border: `1.5px solid ${INK}`, background: PAPER, minHeight: "calc(100vh - 28px)", overflow: "hidden", display: "flex", flexDirection: "column" }}
+      >
+        {/* decorative rotated labels */}
+        <div style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%) rotate(-90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>© MMXXVI</div>
+        <div style={{ position: "absolute", right: 12, top: "50%", transform: "translateY(-50%) rotate(90deg)", font: `700 11px/1 ${mono}`, letterSpacing: ".22em", color: INK, opacity: 0.55, whiteSpace: "nowrap", zIndex: 25 }}>HANDMADE — ITALY</div>
+
+        {/* masthead */}
+        <header style={{ position: "relative", zIndex: 20, padding: "34px clamp(28px,5vw,64px) 0" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", font: `700 12px/1.5 ${mono}`, letterSpacing: ".16em", color: INK }}>
+            <span>GORLIUM</span>
+            <span style={{ opacity: 0.55 }}>HUB OF WORLDS</span>
+          </div>
+          <div style={{ font: `900 clamp(54px,11vw,150px)/.86 ${sans}`, letterSpacing: "-.035em", color: INK, marginTop: 18 }}>gorlium</div>
+        </header>
+
+        {/* content */}
+        <div ref={contentRef} style={{ position: "relative", flex: 1, minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
+          {/* preview: image + description, tracks the active row */}
+          <div
+            style={{
+              position: "absolute", left: 0, width: 300, zIndex: 16,
+              top: rowCenter, transform: "translateY(-50%)",
+              opacity: cur ? 1 : 0, pointerEvents: "none",
+              display: "flex", gap: 18, alignItems: "flex-start",
+            }}
+          >
+            {cur && (
+              <>
+                <img src={cur.img} alt="" style={{ width: 150, height: 112, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}` }} />
+                <div style={{ font: `400 14px/1.45 ${mono}`, color: INK, maxWidth: 140 }}>
+                  {cur.desc}
+                  {cur.restricted && <span style={{ opacity: 0.55 }}> — restricted area.</span>}
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* giant bleeding name behind the list, tracks the active row */}
+          <div
+            style={{
+              position: "absolute", left: "calc(54% + 120px)", font: `800 clamp(52px,8vw,132px)/.84 ${sans}`,
+              letterSpacing: "-.035em", whiteSpace: "nowrap", color: giantTone, zIndex: 4, pointerEvents: "none",
+              top: rowCenter, transform: "translateY(-50%)", opacity: cur ? 0.42 : 0,
+            }}
+          >
+            {cur ? cur.name : ""}
+          </div>
+
+          {/* decentered list */}
+          <div style={{ position: "absolute", left: "54%", top: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
+            <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
+
+            {WORLDS.map((it, i) => {
+              const on = active === i;
+              const enabled = it.href != null;
+              const sharedStyle: React.CSSProperties = {
+                display: "flex", alignItems: "center", gap: 12, padding: "15px 0", color: INK,
+                cursor: enabled ? "pointer" : "default", textDecoration: "none",
+                transform: on ? "translateX(16px)" : "translateX(0)",
+                transition: "transform .18s ease",
+                opacity: enabled ? 1 : 0.62,
+              };
+              const inner = (
+                <>
+                  <span style={{ opacity: on ? 1 : 0, font: `400 20px/1 ${sans}`, marginLeft: -26, width: 14 }}>•</span>
+                  <span style={{ font: `${on ? 800 : 500} clamp(24px,2.4vw,31px)/1 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
+                  {it.restricted && (
+                    <span style={{ font: `700 8px/1 ${mono}`, letterSpacing: ".12em", border: "1px solid currentColor", padding: "4px 5px", opacity: 0.7, whiteSpace: "nowrap" }}>RESTRICTED</span>
+                  )}
+                </>
+              );
+              const setRef = (el: HTMLElement | null) => {
+                itemRefs.current[i] = el;
+              };
+              return enabled ? (
+                <a
+                  key={it.slug}
+                  href={it.href as string}
+                  ref={setRef}
+                  onMouseEnter={() => setActive(i)}
+                  style={sharedStyle}
+                >
+                  {inner}
+                </a>
+              ) : (
+                <div
+                  key={it.slug}
+                  ref={setRef}
+                  onMouseEnter={() => setActive(i)}
+                  aria-disabled="true"
+                  style={sharedStyle}
+                >
+                  {inner}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* footer */}
+        <div style={{ position: "relative", zIndex: 20, display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: `1.5px solid ${INK}`, margin: "0 clamp(28px,5vw,64px)", padding: "16px 0 28px", font: `700 11px/1 ${mono}`, letterSpacing: ".16em", color: INK }}>
+          <span>© GORLIUM</span>
+          <span style={{ opacity: 0.55 }}>SIX WORLDS</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Hub;

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -185,6 +185,7 @@
 /* ===== Header ===== */
 .g-header {
   border-bottom: var(--g-bw) solid var(--g-ink);
+  width: 100%;
 }
 .g-header__cell {
   display: flex;
@@ -195,6 +196,9 @@
   cursor: pointer;
   border-right: var(--g-bw) solid var(--g-border);
   transition: background-color 0.1s ease, color 0.1s ease;
+}
+.g-header__cell:last-child {
+  border-right: none;
 }
 .g-header__cell:hover {
   background: var(--g-accent);
@@ -210,6 +214,24 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 1.25rem;
+}
+
+/* On phones the 5 cells stack into one tall column; lay them out as compact
+   wrapping rows (3 + 2) at a smaller size instead. */
+@media (max-width: 767px) {
+  .g-header .g-tiles {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .g-header__cell {
+    flex: 1 1 33.333%;
+    min-height: 0;
+    padding: 12px 8px;
+  }
+  .g-header__link {
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+  }
 }
 
 /* ===== Form ===== */


### PR DESCRIPTION
## Cosa

Aggiunge un **hub di homepage di primo livello** su `/` che porta alle diverse aree tematiche. L'attuale sito a tema terrari diventa **una** di queste aree, montata sotto `/terrariums`. Ogni area è un "sotto-sito" isolato, libero di avere uno stile diverso.

Mockup importato dall'handoff di Claude Design (`gorlium.dc.html`).

## Hub (`/`)

- Componente standalone ([`Hub.tsx`](packages/app/src/pages/Hub.tsx)), stile proprio (Archivo + Space Mono, palette paper/ink) — **non** eredita la chrome né il design system dei terrari.
- 6 mondi; hover → bullet + bold + nome gigante in accent + immagine/descrizione.
- Solo **Terrariums** cliccabile → `/terrariums`. Gli altri 5 (Tailoring, Jewelry, Knitting & Crochet, Software & Development, Mental Health) sono visibili ma **non cliccabili**. Mental Health ha il badge `RESTRICTED`.

## Area terrari (`/terrariums/*`)

Nidificata sotto `/terrariums` con la chrome originale (Header + Banner) e un link **← GORLIUM HUB** per tornare.

| URL | pagina |
|---|---|
| `/terrariums` | hero (logo + terrario) |
| `/terrariums/gallery` | post terrari |
| `/terrariums/how-to` | istruzioni |
| `/terrariums/contacts` | contatti |
| `/terrariums/dev` | GitHub |

## Altro

- **Tutto in inglese**: default i18n `it → en` (en.json già completo).
- 6 SVG placeholder on-brand in `public/gorlium/` (da sostituire con foto vere).
- Font Google in `index.html`.
- Routing react-router nidificato via `Outlet`.

## Verifica

- `pnpm --filter @gorlium/app build` ✅ — typecheck + build verdi, nessun errore console.
- Verificato a video: hub, hover, e le route annidate dell'area terrari (in inglese).

## Follow-up noti (non in questa PR)

- Nessun redirect dai vecchi URL flat (`/instructions`, `/contacts`, `/dev`, vecchia pagina post su `/terrariums`) → cambiano significato / 404. Posso aggiungere 301.
- Breve flash scuro iniziale sull'hub chiaro (body bg `#0e1410` in `index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)