### PR TITLE
fix(hub): list clipped when zoomed / short viewport

### DIFF
--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -146,7 +146,7 @@ function Hub() {
           </div>
         ) : (
           /* ---------- desktop: decentred list + hover preview ---------- */
-          <div ref={contentRef} style={{ position: "relative", flex: 1, minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
+          <div ref={contentRef} style={{ position: "relative", flex: "1 0 auto", minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
             {/* preview: image + description, tracks the active row */}
             <div
               style={{
@@ -178,8 +178,10 @@ function Hub() {
               {cur ? cur.name : ""}
             </div>
 
-            {/* decentered list */}
-            <div style={{ position: "absolute", left: "54%", top: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
+            {/* decentered list — kept in normal flow so it drives the content
+                height; when the viewport is short/zoomed the page scrolls
+                instead of the list being clipped under the footer. */}
+            <div style={{ position: "relative", marginLeft: "54%", paddingTop: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
               <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
 
               {WORLDS.map((it, i) => {


### PR DESCRIPTION
## Problema

Sull'hub (`/`), con lo **zoom del browser >100%** (o una viewport più bassa), la lista dei mondi sforava sotto il footer e veniva **tagliata** dall'`overflow: hidden` del card (Mental Health + footer non visibili).

## Causa

La lista desktop era in **posizionamento assoluto**, quindi non contribuiva all'altezza del contenuto: su poco spazio verticale superava il card a 100vh fisso e veniva clippata.

## Fix

- Lista rimessa nel **flusso normale** (`margin-left: 54%` invece di `absolute`), così guida l'altezza del contenuto.
- Area contenuto `flex: 1 0 auto` → cresce fino al suo contenuto.

Risultato: quando lo spazio è poco il card cresce e la **pagina scrolla** invece di tagliare; titolo gigante e preview restano overlay assoluti. Desktop a zoom normale invariato (e Mental Health non tocca più il footer).

## Verifica

- 1440×900: lista completa, footer in fondo, nessuno scroll (fits esatto).
- 900×520 (simula zoom): scrolla, nulla tagliato (footer e Mental Health entro il card).
- Build verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)