### PR TITLE
chore(ts7) [1/5]: prep for TypeScript 7 — zero behavior change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .env
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "start": "vite"
   },

--- a/packages/app/src/pages/Instructions.module.css
+++ b/packages/app/src/pages/Instructions.module.css
@@ -45,7 +45,6 @@
 }
 
 .condensation-text-container {
-  margintop: 1vh;
   max-width: 30vw;
   min-width: 10vw;
   text-align: left;

--- a/packages/app/tsconfig.app.json
+++ b/packages/app/tsconfig.app.json
@@ -1,5 +1,0 @@
-{
-  "include": [
-    "packages/app/src"
-  ]
-}

--- a/packages/app/tsconfig.tsbuildinfo
+++ b/packages/app/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.tsx","./src/i18next.d.ts","./src/main.tsx","./src/vite-env.d.ts","./src/pages/contacts.tsx","./src/pages/dev.tsx","./src/pages/homepage.tsx","./src/pages/instructions.tsx","./src/pages/lore.tsx","./src/pages/terrariums.tsx"],"version":"5.7.3"}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -8,6 +8,7 @@
   "author": "",
   "scripts": {
     "build": "tsup --minify --clean",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "start": "tsup --watch"
   },
   "files": [

--- a/packages/design-system/src/css.d.ts
+++ b/packages/design-system/src/css.d.ts
@@ -1,0 +1,5 @@
+// Global CSS is imported as a side effect from src/index.ts (tokens + styles).
+// tsc 5.x tolerated these imports; the native compiler (TS7/tsgo) resolves
+// side-effect imports too and needs a module declaration for *.css.
+// The app doesn't need this — vite/client already declares "*.css".
+declare module "*.css";

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,9 @@
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
     },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
     "start": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
**Stack PR 1 di 5** — migrazione a TypeScript 7 (tsgo) + leggibilità. Base: `main`.
Piano completo: `PLAN-ts7-readability.md` (codex-approved).

Prep a **rischio zero, nessun cambio di comportamento**.

- **design-system**: aggiunto `src/css.d.ts` (`declare module "*.css"`) → il compiler nativo (tsgo) risolve gli import side-effect di `tokens.css`/`styles.css` che davano `TS2882`. tsc 5.7 li tollerava, TS7 no. L'app non ne ha bisogno (`vite/client` dichiara già `*.css`).
- rimosso `packages/app/tsconfig.app.json` (orfano, `include` non risolveva, referenziato da nessuno).
- untrack di `packages/app/tsconfig.tsbuildinfo` (artefatto) + gitignore `*.tsbuildinfo`.
- fix della dichiarazione invalida `margintop` in `Instructions.module.css` (la regola aveva già un `margin-top: 4vh` valido in effetto → **nessun cambio visivo**).
- aggiunti script `typecheck` a entrambi i package + task `typecheck` in turbo. Il design-system prima **non veniva mai typecheckato** (build = tsup/esbuild).

### Verifica
- `pnpm build` verde
- `tsc` typecheck verde su entrambi i package
- check nativo ad-hoc `@typescript/native-preview -p <pkg>` = **0 errori** su entrambi

🤖 Generated with [Claude Code](https://claude.com/claude-code)