### PR TITLE
refactor [3/5]: readability / SRP / DRY (no behavior change)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,6 @@
     "@gorlium/design-system": "workspace:*",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
-    "connect-history-api-fallback": "^2.0.0",
     "i18next": "^24.2.2",
     "i18next-http-backend": "^3.0.2",
     "react": "18.3.1",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,67 +1,11 @@
-import { Header, Banner, Title, Stack } from "@gorlium/design-system";
-import { Route, BrowserRouter, Routes, Outlet, Link } from "react-router-dom";
+import { Route, BrowserRouter, Routes } from "react-router-dom";
 import Hub from "./pages/Hub";
-import Homepage from "./pages/Homepage";
+import TerrariumLayout from "./layouts/TerrariumLayout";
+import TerrariumHome from "./pages/TerrariumHome";
 import Terrariums from "./pages/Terrariums";
 import Dev from "./pages/Dev";
 import Contacts from "./pages/Contacts";
-import { useTranslation } from "react-i18next";
 import { Instructions } from "./pages/Instructions";
-
-// The terrarium area keeps the original digital-brutalism chrome (Header +
-// Banner). Other hub worlds will get their own layouts as they're built.
-function TerrariumLayout() {
-  const { t } = useTranslation();
-
-  return (
-    <div style={{ maxWidth: "1400px", margin: "0 auto", overflow: "hidden" }}>
-      <Stack
-        space={16}
-        align={{
-          mobile: "center",
-          tablet: "center",
-          desktop: "center",
-          wide: "center",
-        }}
-      >
-        <Link
-          to="/"
-          style={{
-            alignSelf: "flex-start",
-            margin: "8px 0 0 8px",
-            font: "700 11px/1 'Space Mono', monospace",
-            letterSpacing: ".16em",
-            color: "inherit",
-            textDecoration: "none",
-            opacity: 0.7,
-          }}
-        >
-          ← GORLIUM HUB
-        </Link>
-        <Header
-          list={[
-            [t("header.home"), "/terrariums"],
-            [t("header.terrariums"), "/terrariums/gallery"],
-            [t("header.instructions"), "/terrariums/how-to"],
-            [t("header.contacts"), "/terrariums/contacts"],
-            [t("header.dev"), "/terrariums/dev"],
-          ]}
-        />
-        <div
-          style={{
-            height: "100%",
-            width: "100%",
-          }}
-        >
-          <Outlet />
-        </div>
-        <Banner>
-          <Title size={"medium"}>{t("bannerWelcome")}</Title>
-        </Banner>
-      </Stack>
-    </div>
-  );
-}
 
 function App() {
   return (
@@ -69,7 +13,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Hub />} />
         <Route path="/terrariums" element={<TerrariumLayout />}>
-          <Route index element={<Homepage />} />
+          <Route index element={<TerrariumHome />} />
           <Route path="gallery" element={<Terrariums />} />
           <Route path="how-to" element={<Instructions />} />
           <Route path="contacts" element={<Contacts />} />

--- a/packages/app/src/layouts/TerrariumLayout.tsx
+++ b/packages/app/src/layouts/TerrariumLayout.tsx
@@ -1,0 +1,60 @@
+import { Header, Banner, Title, Stack } from "@gorlium/design-system";
+import { Outlet, Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+// The terrarium area keeps the original digital-brutalism chrome (Header +
+// Banner). Other hub worlds will get their own layouts as they're built.
+function TerrariumLayout() {
+  const { t } = useTranslation();
+
+  return (
+    <div style={{ maxWidth: "1400px", margin: "0 auto", overflow: "hidden" }}>
+      <Stack
+        space={16}
+        align={{
+          mobile: "center",
+          tablet: "center",
+          desktop: "center",
+          wide: "center",
+        }}
+      >
+        <Link
+          to="/"
+          style={{
+            alignSelf: "flex-start",
+            margin: "8px 0 0 8px",
+            font: "700 11px/1 'Space Mono', monospace",
+            letterSpacing: ".16em",
+            color: "inherit",
+            textDecoration: "none",
+            opacity: 0.7,
+          }}
+        >
+          ← GORLIUM HUB
+        </Link>
+        <Header
+          list={[
+            [t("header.home"), "/terrariums"],
+            [t("header.terrariums"), "/terrariums/gallery"],
+            [t("header.instructions"), "/terrariums/how-to"],
+            [t("header.contacts"), "/terrariums/contacts"],
+            [t("header.dev"), "/terrariums/dev"],
+          ]}
+        />
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+          }}
+        >
+          <Outlet />
+        </div>
+        <Banner>
+          <Title size={"medium"}>{t("bannerWelcome")}</Title>
+        </Banner>
+      </Stack>
+    </div>
+  );
+}
+
+export default TerrariumLayout;

--- a/packages/app/src/lib/preloadImage.ts
+++ b/packages/app/src/lib/preloadImage.ts
@@ -1,0 +1,5 @@
+// Warms the browser cache for an image URL so it's ready before it's shown.
+export function preloadImage(url: string) {
+  const img = new Image();
+  img.src = url;
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -64,14 +64,13 @@
       }
     },
     "instructions": {
-      "title": "How to take care of your terrarium 🌱",
-      "step1": {
-        "title": "Where to place it",
+      "maintenance": {
+        "title": "Minimal maintenance",
         "content": [
-          "Put your terrarium in a bright spot, but avoid direct sunlight. Sun rays can overheat the glass and damage the plants. Indirect, diffused light is best."
+          "If you bought a terrarium from me, you won’t need to worry too much: my terrariums are already “stabilized” and require very little care. Just check the condensation once in a while and intervene only if needed."
         ]
       },
-      "step2": {
+      "condensation": {
         "title": "Checking condensation",
         "content": [
           "Take a look at the glass every now and then:",
@@ -80,10 +79,10 @@
           "Condensation covering most of the glass → the terrarium is too humid. Leave the lid slightly open for about 10 minutes a day and repeat until humidity is balanced again."
         ]
       },
-      "step3": {
-        "title": "Minimal maintenance",
+      "placement": {
+        "title": "Where to place it",
         "content": [
-          "If you bought a terrarium from me, you won’t need to worry too much: my terrariums are already “stabilized” and require very little care. Just check the condensation once in a while and intervene only if needed."
+          "Put your terrarium in a bright spot, but avoid direct sunlight. Sun rays can overheat the glass and damage the plants. Indirect, diffused light is best."
         ]
       }
     }

--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -11,7 +11,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
  * Desktop keeps the original hover layout (decentred list + bleeding giant
  * title + floating preview). On narrow screens hover doesn't exist and the
  * absolute positioning overlaps, so we render a simple stacked, always-on list
- * instead. Only enabled worlds navigate on click.
+ * instead (HubDesktopList / HubMobileList below). Only enabled worlds navigate.
  */
 
 const INK = "#15140f";
@@ -58,6 +58,142 @@ function useIsMobile() {
   return isMobile;
 }
 
+// Mobile: a stacked, always-on list (no hover). Each world is a tappable row
+// with a thumbnail, name and description.
+function HubMobileList() {
+  return (
+    <div style={{ position: "relative", zIndex: 18, flex: 1, padding: "28px clamp(18px,6vw,28px) 8px" }}>
+      <div style={{ font: `800 14px/1 ${sans}`, letterSpacing: ".02em", color: INK, marginBottom: 22, textTransform: "uppercase", opacity: 0.7 }}>My worlds</div>
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {WORLDS.map((it) => {
+          const enabled = it.href != null;
+          const rowStyle: React.CSSProperties = {
+            display: "flex", alignItems: "center", gap: 14, padding: "14px 0", color: INK,
+            textDecoration: "none", borderTop: `1px solid ${INK}22`,
+            opacity: enabled ? 1 : 0.6, cursor: enabled ? "pointer" : "default",
+          };
+          const inner = (
+            <>
+              <img src={it.img} alt="" style={{ width: 64, height: 48, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}`, borderLeft: `4px solid ${it.accent}` }} />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                  <span style={{ font: `700 21px/1.05 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
+                  {it.restricted && RESTRICTED_BADGE}
+                </div>
+                <div style={{ font: `400 12px/1.4 ${mono}`, color: INK, opacity: 0.7, marginTop: 4 }}>{it.desc}</div>
+              </div>
+            </>
+          );
+          return enabled ? (
+            <a key={it.slug} href={it.href as string} style={rowStyle}>{inner}</a>
+          ) : (
+            <div key={it.slug} aria-disabled="true" style={rowStyle}>{inner}</div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface HubDesktopListProps {
+  active: number | null;
+  setActive: (i: number | null) => void;
+  cur: World | null;
+  rowCenter: number;
+  contentRef: React.RefObject<HTMLDivElement>;
+  itemRefs: React.MutableRefObject<(HTMLElement | null)[]>;
+}
+
+// Desktop: the decentred list with the floating preview and the giant bleeding
+// name that both track the hovered row (positioned by the parent's layout effect).
+function HubDesktopList({ active, setActive, cur, rowCenter, contentRef, itemRefs }: HubDesktopListProps) {
+  const giantTone = cur ? cur.accent : INK;
+  return (
+    <div ref={contentRef} style={{ position: "relative", flex: "1 0 auto", minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
+      {/* preview: image + description, tracks the active row */}
+      <div
+        style={{
+          position: "absolute", left: 0, width: 300, zIndex: 16,
+          top: rowCenter, transform: "translateY(-50%)",
+          opacity: cur ? 1 : 0, pointerEvents: "none",
+          display: "flex", gap: 18, alignItems: "flex-start",
+        }}
+      >
+        {cur && (
+          <>
+            <img src={cur.img} alt="" style={{ width: 150, height: 112, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}` }} />
+            <div style={{ font: `400 14px/1.45 ${mono}`, color: INK, maxWidth: 140 }}>
+              {cur.desc}
+              {cur.restricted && <span style={{ opacity: 0.55 }}> — restricted area.</span>}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* giant bleeding name behind the list, tracks the active row */}
+      <div
+        style={{
+          position: "absolute", left: "calc(54% + 120px)", font: `800 clamp(52px,8vw,132px)/.84 ${sans}`,
+          letterSpacing: "-.035em", whiteSpace: "nowrap", color: giantTone, zIndex: 4, pointerEvents: "none",
+          top: rowCenter, transform: "translateY(-50%)", opacity: cur ? 0.42 : 0,
+        }}
+      >
+        {cur ? cur.name : ""}
+      </div>
+
+      {/* decentered list — kept in normal flow so it drives the content
+          height; when the viewport is short/zoomed the page scrolls
+          instead of the list being clipped under the footer. */}
+      <div style={{ position: "relative", marginLeft: "54%", paddingTop: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
+        <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
+
+        {WORLDS.map((it, i) => {
+          const on = active === i;
+          const enabled = it.href != null;
+          const sharedStyle: React.CSSProperties = {
+            display: "flex", alignItems: "center", gap: 12, padding: "15px 0", color: INK,
+            cursor: enabled ? "pointer" : "default", textDecoration: "none",
+            transform: on ? "translateX(16px)" : "translateX(0)",
+            transition: "transform .18s ease",
+            opacity: enabled ? 1 : 0.62,
+          };
+          const inner = (
+            <>
+              <span style={{ opacity: on ? 1 : 0, font: `400 20px/1 ${sans}`, marginLeft: -26, width: 14 }}>•</span>
+              <span style={{ font: `${on ? 800 : 500} clamp(24px,2.4vw,31px)/1 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
+              {it.restricted && RESTRICTED_BADGE}
+            </>
+          );
+          const setRef = (el: HTMLElement | null) => {
+            itemRefs.current[i] = el;
+          };
+          return enabled ? (
+            <a
+              key={it.slug}
+              href={it.href as string}
+              ref={setRef}
+              onMouseEnter={() => setActive(i)}
+              style={sharedStyle}
+            >
+              {inner}
+            </a>
+          ) : (
+            <div
+              key={it.slug}
+              ref={setRef}
+              onMouseEnter={() => setActive(i)}
+              aria-disabled="true"
+              style={sharedStyle}
+            >
+              {inner}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function Hub() {
   const isMobile = useIsMobile();
   const [active, setActive] = useState<number | null>(null);
@@ -87,7 +223,6 @@ function Hub() {
   }, [active, isMobile]);
 
   const cur = active != null ? WORLDS[active] : null;
-  const giantTone = cur ? cur.accent : INK;
 
   return (
     <div style={{ position: "relative", width: "100%", background: BG, padding: isMobile ? 8 : 14, minHeight: "100vh", boxSizing: "border-box", fontFamily: sans }}>
@@ -113,121 +248,16 @@ function Hub() {
         </header>
 
         {isMobile ? (
-          /* ---------- mobile: stacked, always-on list ---------- */
-          <div style={{ position: "relative", zIndex: 18, flex: 1, padding: "28px clamp(18px,6vw,28px) 8px" }}>
-            <div style={{ font: `800 14px/1 ${sans}`, letterSpacing: ".02em", color: INK, marginBottom: 22, textTransform: "uppercase", opacity: 0.7 }}>My worlds</div>
-            <div style={{ display: "flex", flexDirection: "column" }}>
-              {WORLDS.map((it) => {
-                const enabled = it.href != null;
-                const rowStyle: React.CSSProperties = {
-                  display: "flex", alignItems: "center", gap: 14, padding: "14px 0", color: INK,
-                  textDecoration: "none", borderTop: `1px solid ${INK}22`,
-                  opacity: enabled ? 1 : 0.6, cursor: enabled ? "pointer" : "default",
-                };
-                const inner = (
-                  <>
-                    <img src={it.img} alt="" style={{ width: 64, height: 48, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}`, borderLeft: `4px solid ${it.accent}` }} />
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                        <span style={{ font: `700 21px/1.05 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
-                        {it.restricted && RESTRICTED_BADGE}
-                      </div>
-                      <div style={{ font: `400 12px/1.4 ${mono}`, color: INK, opacity: 0.7, marginTop: 4 }}>{it.desc}</div>
-                    </div>
-                  </>
-                );
-                return enabled ? (
-                  <a key={it.slug} href={it.href as string} style={rowStyle}>{inner}</a>
-                ) : (
-                  <div key={it.slug} aria-disabled="true" style={rowStyle}>{inner}</div>
-                );
-              })}
-            </div>
-          </div>
+          <HubMobileList />
         ) : (
-          /* ---------- desktop: decentred list + hover preview ---------- */
-          <div ref={contentRef} style={{ position: "relative", flex: "1 0 auto", minHeight: "58vh", margin: "38px clamp(28px,5vw,64px) 0" }}>
-            {/* preview: image + description, tracks the active row */}
-            <div
-              style={{
-                position: "absolute", left: 0, width: 300, zIndex: 16,
-                top: rowCenter, transform: "translateY(-50%)",
-                opacity: cur ? 1 : 0, pointerEvents: "none",
-                display: "flex", gap: 18, alignItems: "flex-start",
-              }}
-            >
-              {cur && (
-                <>
-                  <img src={cur.img} alt="" style={{ width: 150, height: 112, flex: "none", objectFit: "cover", display: "block", border: `1px solid ${INK}` }} />
-                  <div style={{ font: `400 14px/1.45 ${mono}`, color: INK, maxWidth: 140 }}>
-                    {cur.desc}
-                    {cur.restricted && <span style={{ opacity: 0.55 }}> — restricted area.</span>}
-                  </div>
-                </>
-              )}
-            </div>
-
-            {/* giant bleeding name behind the list, tracks the active row */}
-            <div
-              style={{
-                position: "absolute", left: "calc(54% + 120px)", font: `800 clamp(52px,8vw,132px)/.84 ${sans}`,
-                letterSpacing: "-.035em", whiteSpace: "nowrap", color: giantTone, zIndex: 4, pointerEvents: "none",
-                top: rowCenter, transform: "translateY(-50%)", opacity: cur ? 0.42 : 0,
-              }}
-            >
-              {cur ? cur.name : ""}
-            </div>
-
-            {/* decentered list — kept in normal flow so it drives the content
-                height; when the viewport is short/zoomed the page scrolls
-                instead of the list being clipped under the footer. */}
-            <div style={{ position: "relative", marginLeft: "54%", paddingTop: 6, width: "min(330px, 42vw)", zIndex: 18 }}>
-              <div style={{ font: `800 16px/1 ${sans}`, letterSpacing: "-.005em", color: INK, marginBottom: 40 }}>My worlds</div>
-
-              {WORLDS.map((it, i) => {
-                const on = active === i;
-                const enabled = it.href != null;
-                const sharedStyle: React.CSSProperties = {
-                  display: "flex", alignItems: "center", gap: 12, padding: "15px 0", color: INK,
-                  cursor: enabled ? "pointer" : "default", textDecoration: "none",
-                  transform: on ? "translateX(16px)" : "translateX(0)",
-                  transition: "transform .18s ease",
-                  opacity: enabled ? 1 : 0.62,
-                };
-                const inner = (
-                  <>
-                    <span style={{ opacity: on ? 1 : 0, font: `400 20px/1 ${sans}`, marginLeft: -26, width: 14 }}>•</span>
-                    <span style={{ font: `${on ? 800 : 500} clamp(24px,2.4vw,31px)/1 ${sans}`, letterSpacing: "-.01em" }}>{it.name}</span>
-                    {it.restricted && RESTRICTED_BADGE}
-                  </>
-                );
-                const setRef = (el: HTMLElement | null) => {
-                  itemRefs.current[i] = el;
-                };
-                return enabled ? (
-                  <a
-                    key={it.slug}
-                    href={it.href as string}
-                    ref={setRef}
-                    onMouseEnter={() => setActive(i)}
-                    style={sharedStyle}
-                  >
-                    {inner}
-                  </a>
-                ) : (
-                  <div
-                    key={it.slug}
-                    ref={setRef}
-                    onMouseEnter={() => setActive(i)}
-                    aria-disabled="true"
-                    style={sharedStyle}
-                  >
-                    {inner}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+          <HubDesktopList
+            active={active}
+            setActive={setActive}
+            cur={cur}
+            rowCenter={rowCenter}
+            contentRef={contentRef}
+            itemRefs={itemRefs}
+          />
         )}
 
         {/* footer */}

--- a/packages/app/src/pages/Instructions.tsx
+++ b/packages/app/src/pages/Instructions.tsx
@@ -58,7 +58,7 @@ function SingleInstruction({
   );
 }
 
-function CondensationInstructions() {
+function CondensationInstructions({ index }: { index: number }) {
   function CondensationCard({
     imgPath,
     content,
@@ -84,7 +84,7 @@ function CondensationInstructions() {
     <>
       <Box style={{ marginTop: "3vh" }}>
         <Title align={"left"} size="medium">
-          {`2. ${t("instructions.step2.title")}`}
+          {`${index}. ${t("instructions.condensation.title")}`}
         </Title>
       </Box>
       <Box
@@ -97,21 +97,21 @@ function CondensationInstructions() {
         }}
       >
         <Body size="medium" align="left">
-          {t("instructions.step2.content", { returnObjects: true })[0]}
+          {t("instructions.condensation.content", { returnObjects: true })[0]}
         </Body>
       </Box>
       <div className={styles["three-columns-container"]}>
         <CondensationCard
           imgPath={half}
-          content={t("instructions.step2.content", { returnObjects: true })[1]}
+          content={t("instructions.condensation.content", { returnObjects: true })[1]}
         />
         <CondensationCard
           imgPath={empty}
-          content={t("instructions.step2.content", { returnObjects: true })[2]}
+          content={t("instructions.condensation.content", { returnObjects: true })[2]}
         />
         <CondensationCard
           imgPath={full}
-          content={t("instructions.step2.content", { returnObjects: true })[3]}
+          content={t("instructions.condensation.content", { returnObjects: true })[3]}
         />
       </div>
     </>
@@ -133,15 +133,15 @@ export function Instructions() {
     >
       <SingleInstruction
         index={1}
-        title={t("instructions.step3.title")}
-        content={t("instructions.step3.content", { returnObjects: true })}
+        title={t("instructions.maintenance.title")}
+        content={t("instructions.maintenance.content", { returnObjects: true })}
       />
-      <CondensationInstructions />
+      <CondensationInstructions index={2} />
       <SingleInstruction
         imgPath={instruction1}
         index={3}
-        title={t("instructions.step1.title")}
-        content={t("instructions.step1.content", { returnObjects: true })}
+        title={t("instructions.placement.title")}
+        content={t("instructions.placement.content", { returnObjects: true })}
       />
     </div>
   );

--- a/packages/app/src/pages/TerrariumHome.tsx
+++ b/packages/app/src/pages/TerrariumHome.tsx
@@ -2,13 +2,10 @@ import { useEffect } from "react";
 import { Box, GorliumImage } from "@gorlium/design-system";
 import terrario2 from "../assets/Terrario2.png";
 import logo from "../assets/croppedLogoDark.png";
+import { preloadImage } from "../lib/preloadImage";
 
-function preloadImage(url: string) {
-  const img = new Image();
-  img.src = url;
-}
-
-function Homepage() {
+// Landing hero of the terrarium area (mounted at /terrariums).
+function TerrariumHome() {
   useEffect(() => {
     preloadImage(terrario2);
     preloadImage(logo);
@@ -27,4 +24,4 @@ function Homepage() {
   );
 }
 
-export default Homepage;
+export default TerrariumHome;

--- a/packages/app/src/pages/Terrariums.tsx
+++ b/packages/app/src/pages/Terrariums.tsx
@@ -4,11 +4,7 @@ import terrario2 from "../assets/Terrario1.png";
 import fila1 from "../assets/Fila1cropped.png";
 import patrick from "../assets/Patrizio.png";
 import { useTranslation } from "react-i18next";
-
-function preloadImage(url: string) {
-  const img = new Image();
-  img.src = url;
-}
+import { preloadImage } from "../lib/preloadImage";
 
 function Terrariums() {
   const { t } = useTranslation();

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,23 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import history from "connect-history-api-fallback";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: "configure-server",
-      configureServer(server) {
-        server.middlewares.use(
-          history({
-            disableDotRule: true,
-            htmlAcceptHeaders: ["text/html", "application/xhtml+xml"],
-          })
-        );
-      },
-    },
-  ],
+  plugins: [react()],
   server: {
     host: "0.0.0.0", // Expose the server to the network
   },

--- a/packages/design-system/src/components/Header.tsx
+++ b/packages/design-system/src/components/Header.tsx
@@ -1,15 +1,14 @@
 import { Box } from "../primitives/Box";
 import { Tiles } from "../primitives/Tiles";
 
-// Header navigation cell (formerly the custom components/Button.tsx). Hover-fill
-// is now driven by CSS (.g-header__cell:hover) on --g-accent.
+// Header navigation cell: the anchor IS the cell, so the whole tile is the
+// click target and the hover-fill (CSS .g-header__cell:hover on --g-accent)
+// covers it. Full page reload is fine for this site.
 function HeaderButton({ link, text }: { link: string; text: string }) {
   return (
-    <div className="g-header__cell" onClick={() => (window.location.href = link)}>
-      <a className="g-header__link" href={link}>
-        {text}
-      </a>
-    </div>
+    <a className="g-header__cell g-header__link" href={link}>
+      {text}
+    </a>
   );
 }
 
@@ -25,11 +24,11 @@ function Header({ list }: HeaderProps) {
         columns={{
           mobile: 1,
           tablet: 1,
-          desktop: 5,
-          wide: 5,
+          desktop: list.length,
+          wide: list.length,
         }}
       >
-        {list.slice(0, 5).map(([item, link], index) => (
+        {list.map(([item, link], index) => (
           <HeaderButton link={link} text={item} key={index} />
         ))}
       </Tiles>

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -202,8 +202,6 @@
 }
 .g-header__cell:hover {
   background: var(--g-accent);
-}
-.g-header__cell:hover .g-header__link {
   color: #0e1410;
 }
 .g-header__link {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@types/react-dom':
         specifier: 18.3.5
         version: 18.3.5(@types/react@18.3.18)
-      connect-history-api-fallback:
-        specifier: ^2.0.0
-        version: 2.0.0
       i18next:
         specifier: ^24.2.2
         version: 24.2.3(typescript@5.7.3)
@@ -1843,11 +1840,6 @@ packages:
   /confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
-
-  /connect-history-api-fallback@2.0.0:
-    resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
-    engines: {node: '>=0.8'}
-    dev: false
 
   /consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}


### PR DESCRIPTION
**Stack PR 3 di 5.** Base: `ts7/02-i18n` (#15). Piano: `PLAN-ts7-readability.md`, PR 3. **Nessun cambio di comportamento** (a parte la semplificazione DOM dell'Header e la doppia-navigazione rimossa).

- **SRP**: `App.tsx` ora è solo routing; la chrome terrari è in `src/layouts/TerrariumLayout.tsx`.
- **rename** `Homepage.tsx` → `TerrariumHome.tsx` (è l'hero di `/terrariums`, non la homepage del sito — quella è `Hub`).
- **Hub.tsx**: il ternario gigante mobile/desktop diviso in due sotto-componenti locali `HubMobileList`/`HubDesktopList` (stesso file, stessi stili). `WORLDS`/`useIsMobile`/`RESTRICTED_BADGE` restano.
- **DRY**: `preloadImage` duplicata → `src/lib/preloadImage.ts` (usata da TerrariumHome + Terrariums).
- **Instructions — numerazione onesta**: chiavi i18n rinominate all'ordine reale (`maintenance`/`condensation`/`placement`) così la chiave non mente più; `CondensationInstructions` riceve `index` invece del "2." hardcoded; rimossa chiave morta `instructions.title`.
- **Header (DS)**: l'`<a>` È la cella (`g-header__cell g-header__link`), via il `div` wrapper e la sua navigazione duplicata; `columns` derivano da `list.length` invece del `5` hardcoded + `slice(0,5)` (DIP). Regola CSS hover adattata.
- **vite.config**: rimosso `connect-history-api-fallback` — il fallback SPA nativo di Vite serve già i deep-link (verificato: `/terrariums/*` → index.html). Rimossa la dipendenza.

### Verifica
- `tsc` typecheck + build verdi su entrambi i package
- deep-link server-request → 200 con `#root` (senza middleware)
- parità runtime: hub (desktop), terrarium home, how-to (numeri 1/2/3, titoli intatti); nessun errore console

🤖 Generated with [Claude Code](https://claude.com/claude-code)