### PR TITLE
build(ts7) [4/5]: switch typecheck + build to native compiler (tsgo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "main": "index.js",
   "scripts": {
     "start": "turbo run start",
-    "build": "turbo run build"
+    "build": "turbo run build",
+    "typecheck": "turbo run typecheck"
   },
   "keywords": [],
   "author": "",
   "packageManager": "pnpm@8.15.4",
   "license": "ISC",
   "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "turbo": "^2.3.3"
   },
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc -b && vite build",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsgo -b && vite build",
+    "typecheck": "tsgo -b",
     "lint": "eslint .",
     "start": "vite"
   },

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "scripts": {
     "build": "tsup --minify --clean",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
     "start": "tsup --watch"
   },
   "files": [

--- a/packages/design-system/tsup.config.ts
+++ b/packages/design-system/tsup.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   entry: ["src/index.ts"],
   outDir: "dist",
   format: ["esm"],
+  // dts uses tsup's rollup-plugin-dts, which drives the classic `typescript`
+  // (5.x) JS API. The native compiler (tsgo, used for `typecheck`) doesn't
+  // expose that API yet, so this package keeps `typescript` as a devDependency
+  // solely for emitting these declarations. Drop it once tsup supports native.
   dts: true,
   // Global CSS (tokens + component styles) is imported as a side effect from
   // src/index.ts and bundled by esbuild into dist/index.css.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^0.34.3
         version: 0.34.3
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
       turbo:
         specifier: ^2.3.3
         version: 2.5.6
@@ -1650,6 +1653,83 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.42.0
       eslint-visitor-keys: 4.2.1
+    dev: true
+
+  /@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
     dev: true
 
   /@vitejs/plugin-react@4.7.0(vite@6.3.5):


### PR DESCRIPTION
**Stack PR 4 di 5.** Base: `ts7/03-readability` (#16). Piano: `PLAN-ts7-readability.md`, PR 4.

Lo switch vero e proprio al compiler nativo di TypeScript 7 (`tsgo`).

- `@typescript/native-preview` come devDependency alla **root** del workspace (una sola versione; fornisce il bin `tsgo` a entrambi i package).
- **app**: `build` → `tsgo -b && vite build`; `typecheck` → `tsgo -b`.
- **design-system**: `typecheck` → `tsgo -p tsconfig.json --noEmit`. Il pacchetto **tiene** `typescript` 5.x come devDep SOLO per `tsup --dts` (rollup-plugin-dts usa l'API JS classica di TS, che tsgo non espone ancora) — motivazione documentata in `tsup.config.ts`.
- aggiunto script root `typecheck` (`turbo run typecheck`).

### Verifica
- `pnpm build` e `pnpm typecheck` verdi via tsgo su entrambi i package
- confermato che `tsgo -b` **fa da gate** reale (un errore di tipo introdotto apposta fa fallire il check)
- il bundle si è pure ridotto (rimozione dead code delle PR precedenti)
- ⏳ la **deploy-preview Netlify** valida che il binario nativo builda su Linux

### Nota
Quando TS7 stable uscirà come `typescript@7`: sostituire il preview alla root con la major e rimuovere il doppio binario nel design-system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)