### PR TITLE
chore(ts7) [5/5]: verbatimModuleSyntax + isolatedModules + shared tsconfig

### DIFF
--- a/packages/app/eslint.config.js
+++ b/packages/app/eslint.config.js
@@ -23,6 +23,9 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
+      // Enforce `import type` so transpile-per-file tools (Vite/esbuild) and
+      // verbatimModuleSyntax agree on what gets elided.
+      "@typescript-eslint/consistent-type-imports": "error",
     },
   }
 );

--- a/packages/app/src/i18next.d.ts
+++ b/packages/app/src/i18next.d.ts
@@ -1,4 +1,4 @@
-import { resources } from "../i18n";
+import type { resources } from "../i18n";
 
 declare module "i18next" {
   interface CustomTypeOptions {

--- a/packages/app/src/pages/Dev.tsx
+++ b/packages/app/src/pages/Dev.tsx
@@ -1,10 +1,10 @@
 import {
   Box,
   Button,
-  IconProps,
   Inline,
   PostSection,
   Stack,
+  type IconProps,
 } from "@gorlium/design-system";
 import githublogo from "../assets/github-mark-white.png";
 import { useTranslation } from "react-i18next";

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,26 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ESNext"
-    ],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "noEmit": true
   },
-  "include": [
-    "src/**/*",
-    "src/i18next.d.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*", "src/i18next.d.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/design-system/src/components/Badge.tsx
+++ b/packages/design-system/src/components/Badge.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface BadgeProps {
   children: ReactNode;

--- a/packages/design-system/src/components/Banner.tsx
+++ b/packages/design-system/src/components/Banner.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { type ReactNode, useState } from "react";
 import Marquee from "react-fast-marquee";
 
 interface BannerProps {

--- a/packages/design-system/src/components/Callout.tsx
+++ b/packages/design-system/src/components/Callout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface CalloutProps {
   title?: ReactNode;

--- a/packages/design-system/src/components/Card.tsx
+++ b/packages/design-system/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface CardProps {
   title?: ReactNode;

--- a/packages/design-system/src/components/GorliumImage.tsx
+++ b/packages/design-system/src/components/GorliumImage.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 import { Box } from "../primitives/Box";
 
 interface GorliumImageProps {

--- a/packages/design-system/src/components/PostSection.tsx
+++ b/packages/design-system/src/components/PostSection.tsx
@@ -1,6 +1,6 @@
-import { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 import { Body, Title } from "../primitives/Text";
-import { Box, BoxWidth } from "../primitives/Box";
+import { Box, type BoxWidth } from "../primitives/Box";
 import { Inline } from "../primitives/Inline";
 import GorliumImage from "./GorliumImage";
 

--- a/packages/design-system/src/components/Tabs.tsx
+++ b/packages/design-system/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { type ReactNode, useState } from "react";
 
 export interface TabsProps {
   tabs: { label: ReactNode; content: ReactNode }[];

--- a/packages/design-system/src/form/Form.tsx
+++ b/packages/design-system/src/form/Form.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Title, Body } from "../primitives/Text";
 import { Button } from "../primitives/Button";
 

--- a/packages/design-system/src/form/FormSection.tsx
+++ b/packages/design-system/src/form/FormSection.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface FormSectionProps {
   children?: ReactNode;

--- a/packages/design-system/src/primitives/Box.tsx
+++ b/packages/design-system/src/primitives/Box.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 
 // Width vocabulary:
 //  - number            → fixed px width (spacer)

--- a/packages/design-system/src/primitives/Button.tsx
+++ b/packages/design-system/src/primitives/Button.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from "react";
-import { IconProps } from "../types";
+import type { ReactNode } from "react";
+import type { IconProps } from "../types";
 
 export interface ButtonProps {
   label: ReactNode;

--- a/packages/design-system/src/primitives/Inline.tsx
+++ b/packages/design-system/src/primitives/Inline.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties, ReactNode } from "react";
-import { alignItemsMap, pickResponsive, Responsive, spacePx } from "../lib/layout";
+import type { CSSProperties, ReactNode } from "react";
+import { alignItemsMap, pickResponsive, type Responsive, spacePx } from "../lib/layout";
 
 export interface InlineProps {
   children?: ReactNode;

--- a/packages/design-system/src/primitives/Link.tsx
+++ b/packages/design-system/src/primitives/Link.tsx
@@ -1,4 +1,4 @@
-import { AnchorHTMLAttributes, ReactNode } from "react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
 
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   children?: ReactNode;

--- a/packages/design-system/src/primitives/Stack.tsx
+++ b/packages/design-system/src/primitives/Stack.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties, ReactNode } from "react";
-import { alignItemsMap, pickResponsive, Responsive, spacePx } from "../lib/layout";
+import type { CSSProperties, ReactNode } from "react";
+import { alignItemsMap, pickResponsive, type Responsive, spacePx } from "../lib/layout";
 
 export interface StackProps {
   children?: ReactNode;

--- a/packages/design-system/src/primitives/Text.tsx
+++ b/packages/design-system/src/primitives/Text.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 type Align = CSSProperties["textAlign"];
 

--- a/packages/design-system/src/primitives/Tiles.tsx
+++ b/packages/design-system/src/primitives/Tiles.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { spacePx } from "../lib/layout";
 
 type TilesColumns =

--- a/packages/design-system/src/provider/GorliumProvider.tsx
+++ b/packages/design-system/src/provider/GorliumProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface GorliumProviderProps {
   children?: ReactNode;

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,23 +1,5 @@
 {
-    "compilerOptions": {
-        "target": "ES2019",
-        "lib": [
-            "DOM",
-            "DOM.Iterable",
-            "ESNext"
-        ],
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "jsx": "react-jsx",
-        "strict": true,
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "include": [
-        "src/**/*"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
**Stack PR 5 di 5** (opzionale, ma pianificata). Base: `ts7/04-switch` (#17). Piano: `PLAN-ts7-readability.md`, PR 5.

Strictness moderna, allinea i tipi alla realtà transpile-per-file di Vite/esbuild/tsup.

- **`tsconfig.base.json`** alla root con le `compilerOptions` condivise (prima duplicate nei due package), ora con `verbatimModuleSyntax` + `isolatedModules`. I due tsconfig fanno `extends` (l'app tiene `allowImportingTsExtensions` + `noEmit`).
- regola ESLint **`@typescript-eslint/consistent-type-imports`** nell'app per non regredire.
- corretti tutti i type-only import emersi dai nuovi flag: `import type` / qualifier inline `type` nell'app (i18next.d.ts, Dev.tsx via `eslint --fix`) e nel design-system (**17 file**: ReactNode/CSSProperties/FC/ComponentProps/Responsive/BoxWidth/IconProps/…).

### Verifica
- `pnpm typecheck` (tsgo) verde su entrambi i package con i nuovi flag
- `eslint` pulito
- build verde
- smoke test runtime del form contacts (DS-heavy) → OK, nessun errore console

🤖 Generated with [Claude Code](https://claude.com/claude-code)