### PR TITLE
feat(baltici): Splitwise-light area (InstantDB, no login)

### DIFF
--- a/ANALISI-riscrittura-seamly2d-typescript.md
+++ b/ANALISI-riscrittura-seamly2d-typescript.md
@@ -1,0 +1,375 @@
+# Riscrittura di Seamly2D in TypeScript (web app): analisi degli ostacoli
+
+> Analisi basata sull'ispezione diretta del sorgente di [FashionFreedom/Seamly2D](https://github.com/FashionFreedom/Seamly2D)
+> (clone del 2026-07-10, branch di default). I path citati si riferiscono a quel repo.
+> Dove un'affermazione è inferita e non verificata sul codice, è marcata **[inferito]**.
+
+## TL;DR
+
+Non ci sono ostacoli *teorici* insormontabili: è geometria 2D + un parser di formule + una UI,
+tutto esprimibile in TypeScript/browser. Gli ostacoli reali sono:
+
+1. **La mole**: ~257k righe di C++ (esclusi i binari Xerces vendorizzati), di cui la parte
+   dominante è UI interattiva — 57 tool di disegno, 46 dialog, 52 comandi di undo, 225 file
+   che toccano `QGraphicsScene`/`QGraphicsItem`. Non è "un motore da portare", è un CAD completo.
+2. **La compatibilità con il formato file** è il vincolo più duro: per aprire i `.val` esistenti
+   serve replicare *esattamente* la semantica di valutazione (formule, variabili automatiche,
+   ordine di ricalcolo, algoritmi delle curve) — non basta "somigliare".
+3. **Tre sottosistemi senza equivalente browser pronto**: validazione XSD, export EPS/PS via
+   binario esterno `pdftops`, e il nesting multithread dei pezzi.
+4. **L'architettura di Seamly2D non va copiata**: usa il DOM XML come source of truth anche per
+   l'undo — una riscrittura è una ri-progettazione, non una traduzione.
+
+Stima d'ordine di grandezza: una riscrittura *completa e file-compatible* è un progetto
+pluriennale per un team; un *sottoinsieme utile* (motore parametrico + editor con i 10–15 tool
+più usati + export SVG/PDF) è fattibile in mesi. **[inferito — stima, non misurata]**
+
+---
+
+## 1. Cosa c'è dentro Seamly2D (verificato sul codice)
+
+| Sottosistema | Dove | Dimensione / note |
+|---|---|---|
+| Motore parametrico (variabili, ricalcolo) | `src/libs/vpatterndb` (`VContainer`), `src/libs/ifc/xml/vabstractpattern.h` (`FullUpdateFromFile`, `LiteParseTree`) | Il pattern è un grafo di oggetti geometrici guidato da formule; al cambio di un valore l'albero viene ri-parsato |
+| Parser di formule | `src/libs/qmuparser` (fork di muParser, statico) | ~30+ funzioni (`sin/cosD/atan2/log/…`), separatori decimali localizzati |
+| Geometria | `src/libs/vgeometry` | Punti, linee, archi, archi ellittici, spline cubiche, spline path (Bézier) |
+| Tool interattivi | `src/libs/vtools/tools` (57 .cpp), `src/libs/vtools/dialogs` (46 .cpp) | Ogni tool = classe grafica + dialog + comando undo |
+| Undo/redo | `src/libs/vtools/undocommands` (52 file) | I comandi manipolano direttamente il DOM XML |
+| Nesting (layout automatico pezzi) | `src/libs/vlayout` (~6.400 LOC) | Bin-packing custom con collision detection e parallelismo `QThreadPool` |
+| Margini di cucitura | `VAbstractPiece::Equidistant` in `src/libs/vlayout/vabstractpiece.h` | Offset poligonale custom con correzione dei punti degeneri |
+| Export DXF | `src/libs/vdxf` (libdxfrw vendorizzato) | Include **AAMA/ASTM** (formato industriale per plotter/taglio) |
+| Export PS/EPS | `src/app/seamly2d/mainwindowsnogui.cpp` | Genera PDF e lo converte lanciando **`pdftops` (poppler) via `QProcess`** |
+| Formati file | `src/libs/ifc/schema` | XML validato con **XSD via Xerces-C**; **49 versioni di schema** del formato pattern (v0.1.x → v0.7.4) + formati misure individuali/multisize + label template |
+| App misure (SeamlyMe) | `src/app/seamlyme` | App separata: misure individuali e multisize (grading per taglie) |
+| i18n | `share/translations` | 69 file .ts (Qt Linguist), sync Weblate |
+| Auto-update | `src/libs/fervor` | Irrilevante sul web |
+| Stampa | `QPrinter` + poster/tiling (`vposter.cpp`) | Stampa a scala fisica esatta, PDF affiancato multi-pagina |
+
+Stack: C++14, Qt 6.8 (Widgets + QGraphicsScene, `xml svg printsupport network multimedia`), qmake.
+
+---
+
+## 2. Gli ostacoli, dal più duro al più morbido
+
+### 2.1 Compatibilità del formato `.val` — l'ostacolo vero
+
+Il formato pattern non è un formato di *dati* ma un formato di *programma*: contiene la sequenza
+di operazioni di costruzione con formule che referenziano variabili generate automaticamente
+dagli step precedenti (lunghezze di linee, angoli, lunghezze di curva, segmenti). Perché un file
+esistente si apra e produca lo stesso cartamodello, il motore TypeScript deve replicare:
+
+- la **semantica esatta di qmuParser** (precedenze, funzioni, gestione dei locale nei numeri);
+- gli **algoritmi esatti delle curve** di `vgeometry` (parametrizzazione delle spline, calcolo
+  lunghezze, punti di intersezione curva/asse — ci sono 6 famiglie di tool di intersezione);
+- l'**ordine di ricalcolo** del grafo di dipendenze;
+- la **catena di migrazione delle 49 versioni di schema**, se si vogliono aprire file storici.
+
+Piccole divergenze numeriche cambiano il capo cucito. Nota positiva: sia `qreal` che `number`
+JS sono double IEEE-754, quindi la precisione di base non è un problema; lo è la fedeltà
+*algoritmica*. **[verificato l'impianto; l'entità dello sforzo è inferita]**
+
+Se invece si accetta un **formato proprio con importer "best effort"**, questo ostacolo si
+ridimensiona molto — ed è la scelta che suggerirei.
+
+### 2.2 Volume della UI: è qui che vive il costo
+
+57 tool + 46 dialog + 52 undo command + property explorer (`vpropertyexplorer`) + tutta
+l'interazione su canvas (snapping, selezione, drag di control point delle spline, zoom/pan,
+label trascinabili sui pezzi). `QGraphicsScene` non ha un equivalente completo nel browser:
+Canvas2D/SVG/WebGL danno il rendering, ma scene graph con hit-testing, item transform,
+z-ordering e eventi va costruito o preso da librerie (Pixi.js, Konva, paper.js — nessuna copre
+tutto ciò che `QGraphicsScene` + `QGraphicsItem` offrono gratis). **[verificato il volume;
+il gap delle librerie è inferito da conoscenza generale]**
+
+### 2.3 Sottosistemi senza equivalente browser diretto
+
+| Feature C++/Qt | Problema nel browser | Opzioni |
+|---|---|---|
+| Validazione XSD (Xerces) | Nessuna API nativa di validazione XSD nei browser | Riscrivere la validazione a mano (gli schemi sono controllati dal progetto, fattibile), oppure libxml2 compilato in WASM |
+| Export EPS/PS via `pdftops` (QProcess) | Impossibile lanciare processi; poppler non gira nel browser | Rinunciare a EPS/PS, oppure conversione server-side, oppure Ghostscript WASM (esiste ma pesante) |
+| Nesting con `QThreadPool` | Niente thread condivisi; è CPU-bound | Web Worker (parallelismo ok ma serializzazione dei dati), o riscrivere il core del nesting in Rust/WASM. In alternativa adottare un nesting esistente (algoritmo no-fit-polygon alla SVGnest/Deepnest) invece di portare quello custom |
+| `QPrinter` / stampa a scala fisica | La stampa da browser non garantisce la scala | Generare PDF lato client (pdf-lib) con dimensioni fisiche esatte e far stampare il PDF — pattern già usato da FreeSewing **[inferito]** |
+| Offset poligonale (`Equidistant`) | Algoritmo custom pieno di casi limite | Non portarlo: usare Clipper2 (anche in WASM), che è lo standard de-facto per polygon offsetting |
+| DXF AAMA/ASTM | Nessuna lib JS matura per AAMA/ASTM **[non verificato: esistono writer DXF generici JS, la parte AAMA andrebbe scritta]** | La struttura AAMA è documentata; scrivere il writer sopra un serializzatore DXF JS è lavoro contenuto ma di nicchia |
+| File system locale | Le web app non leggono/scrivono file liberamente | File System Access API (solo Chromium) o download/upload; cambia l'UX rispetto a un'app desktop |
+| Font/metriche testo (label sui pezzi, testo in DXF) | Metriche font diverse da Qt | Ricalcolare layout label con misure canvas; divergenze estetiche accettabili |
+
+### 2.4 Architettura da NON replicare
+
+Due scelte di Seamly2D che una riscrittura non dovrebbe copiare (e quindi allontanano ancora di
+più dal "porting"):
+
+- **Il DOM XML è lo stato dell'applicazione**: i 52 undo command modificano `QDomElement` e
+  l'app ri-parsa l'albero (`FullUpdateFromFile`/`LiteParseTree`). In TS la scelta naturale è uno
+  state store immutabile con undo strutturale; il file XML diventa solo serializzazione.
+- **Ricalcolo per ri-parsing** invece di un vero grafo reattivo di dipendenze: costoso e
+  fragile; in una riscrittura si farebbe un DAG incrementale.
+
+Conseguenza: quasi zero codice è "traducibile" meccanicamente; si riscrive la logica leggendo
+quella vecchia come specifica.
+
+### 2.5 Cose che invece NON sono un problema
+
+- **La matematica**: spline cubiche, archi, intersezioni — tutto esprimibile in TS puro; float64
+  identico.
+- **Il parser di formule**: la grammatica di qmuParser è piccola; riscriverla (o adattare
+  math.js/expr-eval con le funzioni gradi/radianti custom) è lavoro di giorni, non mesi.
+- **SVG/PNG/PDF export**: il browser è *migliore* di Qt su SVG; PDF con pdf-lib.
+- **i18n**: i .ts di Qt Linguist sono XML banale da convertire in cataloghi JS.
+- **`network multimedia` / fervor**: usati per update check e suoni **[inferito per multimedia]**;
+  irrilevanti sul web.
+- **SeamlyMe**: le misure individuali/multisize sono dati tabellari + formule; sul web è la
+  parte più facile.
+
+---
+
+## 3. Implicazioni pratiche (in ottica progetto tuo)
+
+1. **Non conviene un "port" 1:1.** Il valore di Seamly2D per una riscrittura è come *specifica
+   di dominio* (quali tool servono, come funziona il grading, formato AAMA, semantica delle
+   formule) — non come codice sorgente. Anche la licenza spinge in questa direzione: Seamly2D è
+   **GPLv3** (LICENSE nel repo), quindi qualunque derivazione del codice vincola il progetto web
+   a GPL; una reimplementazione clean-room no.
+2. **La strada corta resta quella già individuata** nella ricerca precedente: un core parametrico
+   esistente e permissivo come **@freesewing/core (MIT)** — che è già "Seamly2D senza UI, in JS"
+   come modello concettuale (misure → costruzione parametrica → SVG) — più un editor visuale
+   proprio. Gli ostacoli §2.2 (UI) restano tutti, ma spariscono §2.1 (formato) e mezza §2.3.
+3. **Se l'obiettivo è la compatibilità con l'ecosistema Seamly2D** (aprire i .val della
+   community), il costo è dominato dalla fedeltà del motore (§2.1) e va messo in conto un
+   lungo lavoro di golden-testing: file .val reali → confronto geometrico output C++ vs TS.
+4. **Ordine di attacco sensato per un MVP web** (se si parte): motore formule + geometria +
+   ricalcolo DAG (testabile headless) → canvas editor con i tool "punto/linea/intersezione/
+   spline" → pezzi + margini via Clipper2 → export SVG/PDF → nesting (ultimo: è il più costoso
+   e il meno indispensabile all'inizio).
+
+---
+
+## 4. Inventario feature come user stories
+
+Elenco delle funzionalità di Seamly2D estratto dal sorgente (classi tool in `src/libs/vtools/tools`,
+dialog in `src/libs/vtools/dialogs` e `src/app/*/dialogs`, enum `LayoutExportFormat` in
+`src/libs/vmisc/def.h`). Persona: **la modellista** (pattern maker). Le storie sono raggruppate
+per epic; la colonna "Fonte" indica dove la feature vive nel codice C++.
+
+### Epic A — Misure (SeamlyMe)
+
+| ID | User story | Fonte |
+|---|---|---|
+| A1 | Come modellista, voglio creare un file di **misure individuali** (.vit) di una persona, per usarle nelle formule del cartamodello | `src/app/seamlyme`, schema `individual_size_measurements` |
+| A2 | Come modellista, voglio creare **tabelle multisize** (.vst) con valore base e incrementi per taglia/altezza, per graduare lo stesso modello su più taglie | `tmainwindow.h` (`OpenMultisize`), schema `multi_size_measurements` |
+| A3 | Come modellista, voglio scegliere le misure da un **database di misure note** (con codici standard e diagrammi del corpo), per non inventare nomi e sapere dove si prende ogni misura | `dialogmdatabase` |
+| A4 | Come modellista, voglio definire misure **calcolate con formule** che dipendono da altre misure, per derivare valori composti | parser qmuParser condiviso |
+| A5 | Come modellista, voglio lavorare in **cm, mm o pollici**, per usare il mio sistema di unità | preferenze + `def.h` (unit) |
+
+### Epic B — Disegno parametrico (modalità Draft)
+
+| ID | User story | Fonte |
+|---|---|---|
+| B1 | Come modellista, voglio creare **blocchi di disegno** multipli nello stesso file, ognuno con un punto base, per organizzare corpetto/manica/gonna separatamente | `vtoolbasepoint` |
+| B2 | Come modellista, voglio piazzare **punti derivati da altri punti**: a distanza+angolo (endline), lungo una linea (alongline), su normale, su bisettrice, su perpendicolare da un punto (height), su spalla (shoulder point), a contatto con un cerchio (point of contact), come terzo vertice di un triangolo, alle coordinate X/Y di altri due punti | `vtoolendline`, `vtoolalongline`, `vtoolnormal`, `vtoolbisector`, `vtoolheight`, `vtoolshoulderpoint`, `vtoolpointofcontact`, `vtooltriangle`, `point_intersectxy_tool` |
+| B3 | Come modellista, voglio **ogni valore numerico come formula** che referenzia misure, variabili custom e grandezze generate dagli step precedenti (lunghezze/angoli di linee, lunghezze di curve e segmenti), così il modello si adatta da solo a misure diverse | qmuParser + `VContainer` + `dialogvariables` (`fillLineLengths/LineAngles/CurveLengths`) |
+| B4 | Come modellista, voglio tracciare **linee** tra punti con stile e colore configurabili | `vtoolline` |
+| B5 | Come modellista, voglio tracciare **curve**: archi (per angoli o per lunghezza), archi ellittici, spline semplici, spline path a più nodi, Bézier cubiche e percorsi di Bézier, con maniglie di controllo trascinabili | `vtoolarc`, `vtoolarcwithlength`, `vtoolellipticalarc`, `vtoolspline`, `vtoolsplinepath`, `vtoolcubicbezier`, `vtoolcubicbezierpath` |
+| B6 | Come modellista, voglio trovare **punti di intersezione**: linea/linea, linea/asse, curva/asse, cerchio/cerchio, cerchio/tangente, arco/arco, curva/curva, arco/tangente | `vtoollineintersect`, `vtoollineintersectaxis`, `vtoolcurveintersectaxis`, `intersect_circles_tool`, `intersect_circletangent_tool`, `vtoolpointofintersectionarcs`, `vtoolpointofintersectioncurves`, `vtoolpointfromarcandtangent` |
+| B7 | Come modellista, voglio **tagliare** archi, spline e spline path in un punto a distanza data, ottenendo due segmenti riutilizzabili nelle formule | `vtoolcutarc`, `vtoolcutspline`, `vtoolcutsplinepath` |
+| B8 | Come modellista, voglio **operazioni su gruppi di oggetti**: rotazione, traslazione (move), specchiatura rispetto a una linea o a un asse | `operation/vtoolrotation`, `vtoolmove`, `mirror/vtoolmirrorbyline`, `vtoolmirrorbyaxis` |
+| B9 | Come modellista, voglio il tool **true darts** per riposizionare correttamente le gambe di una pince | `vtooltruedarts` |
+| B10 | Come modellista, voglio organizzare gli oggetti in **gruppi con visibilità** on/off, per gestire disegni complessi | `AddGroup`/`DelGroup`/`*GroupItem` undo commands, `groups_widget` |
+| B11 | Come modellista, voglio importare un'**immagine di sfondo** (es. scan di un cartamodello) da ricalcare | `handleImageTool`, `ImageItem` in `mainwindow.h` |
+| B12 | Come modellista, voglio vedere la **cronologia ordinata degli step di costruzione** e navigarla, per capire e correggere il modello | `history_dialog` |
+| B13 | Come modellista, voglio una **tabella delle variabili** (misure, incrementi custom, lunghezze/angoli generati) e una **calcolatrice** di formule, per ispezionare i valori correnti | `dialogvariables`, `calculator_dialog` |
+| B14 | Come modellista, voglio **undo/redo illimitato** su ogni operazione | 52 classi in `vtools/undocommands` |
+
+### Epic C — Pezzi del cartamodello (modalità Piece)
+
+| ID | User story | Fonte |
+|---|---|---|
+| C1 | Come modellista, voglio comporre un **pezzo** selezionando in sequenza punti e curve del disegno, per ottenere il contorno del pezzo da taglio | `pattern_piece_tool`, `vpiece`/`vpiecenode` |
+| C2 | Come modellista, voglio il **margine di cucitura** generato automaticamente, con larghezza globale, override per singolo nodo e regole d'angolo, oppure "built-in" se già disegnato | `VAbstractPiece::Equidistant`, `SetSeamAllowance(BuiltIn)` |
+| C3 | Come modellista, voglio le **tacche (notches)** sui bordi del pezzo, per allineare i pezzi in cucitura | `Notch` in `vpiecenode.h` |
+| C4 | Come modellista, voglio **percorsi interni** al pezzo (pieghe, linee di cucitura interne, decorazioni) | `internal_path_tool` |
+| C5 | Come modellista, voglio **punti di ancoraggio** (anchor points) sul pezzo per bottoni/marche | `anchorpoint_tool` |
+| C6 | Come modellista, voglio il **filo (grainline)** con direzione e frecce configurabili | `floatItemData/vgrainlinedata` |
+| C7 | Come modellista, voglio **etichette su pezzo e cartamodello** con placeholder dinamici (nome, taglia, data, quantità di taglio…), posizionabili e ruotabili sul pezzo | `vtextmanager`, `floatItemData` |
+| C8 | Come modellista, voglio **unire due pezzi** in uno (union), per costruire trasformazioni di modello | `union_tool` |
+
+### Epic D — Piazzamento (modalità Layout)
+
+| ID | User story | Fonte |
+|---|---|---|
+| D1 | Come modellista, voglio il **piazzamento automatico (nesting)** dei pezzi sul tessuto, per minimizzare lo sfrido | `vlayoutgenerator`, `vposition`, `vbank` |
+| D2 | Come modellista, voglio configurare il piano di taglio: **formati carta e rotoli tessuto** (30/36/42/44in, custom), margini, gap tra pezzi, rotazioni consentite, pagine unite | `layoutsettings_dialog`, enum `PaperSizeTemplate` |
+| D3 | Come modellista, voglio vedere l'**avanzamento del nesting** (è calcolo pesante, parallelizzato) e poterlo annullare | `dialoglayoutprogress`, `QThreadPool` |
+
+### Epic E — Export e stampa
+
+| ID | User story | Fonte |
+|---|---|---|
+| E1 | Come modellista, voglio esportare il layout in **SVG, PDF, PNG, JPG, BMP, PPM, TIF, OBJ** | enum `LayoutExportFormat` |
+| E2 | Come modellista, voglio il **PDF affiancato (tiled)** su fogli A4/Letter con crocini, per stampare a casa e incollare i fogli a scala reale | `PDFTiled`, `vposter` |
+| E3 | Come modellista, voglio esportare **PS/EPS** per flussi di stampa professionali | via `pdftops` esterno |
+| E4 | Come professionista, voglio esportare **DXF** in 9 versioni AutoCAD (R10→2013), in variante **flat, AAMA e ASTM**, per mandare i pezzi a plotter e macchine da taglio industriali | `LayoutExportFormat` DXF_*, `vdxfengine` |
+| E5 | Come modellista, voglio **stampare** direttamente (anche tiled) a scala fisica esatta, con anteprima | `QPrinter`, `mainwindowsnogui` |
+
+### Epic F — File, formato e piattaforma
+
+| ID | User story | Fonte |
+|---|---|---|
+| F1 | Come modellista, voglio salvare il cartamodello in un **formato aperto XML (.val)** validato da schema, separato dai file misure, per riusare lo stesso modello con misure diverse | `ifc/schema/pattern` (49 versioni XSD) |
+| F2 | Come modellista, voglio che i **file di versioni vecchie si aprano ancora** (migrazione automatica dello schema) | catena di converter in `ifc` |
+| F3 | Come utente, voglio l'app nella **mia lingua** (decine di lingue) con separatori decimali locali nelle formule | 69 file .ts, qmuParser locale-aware |
+| F4 | Come utente, voglio **preferenze** (unità, tema, comportamenti), **scorciatoie configurabili** e una schermata di benvenuto | `dialogpreferences`, `shortcuts_dialog`, `welcome_dialog` |
+| F5 | Come utente desktop, voglio l'**auto-update** dell'app | `fervor` (irrilevante sul web) |
+
+Copertura: la tabella copre tutti i 57 tool e i dialog principali; non scendono a user story
+le funzioni di contorno (about, decimal chart, pattern properties, zoom/pan/pan della vista).
+
+---
+
+## 5. Scope selezionato per l'app custom (decisioni del 2026-07-13)
+
+Selezione interattiva sulle feature dell'inventario §4, nell'ottica di un'app **consumer**
+molto più semplice di Seamly2D. Visione dichiarata:
+
+> "l'idea è quella di lasciare l'utente inserire le proprie misure in un form e computare il
+> cartamodello eventuale su quei parametri, in modo molto più semplice che seamly"
+
+> "come prima iterazione, i cartamodelli non saranno costruibili dall'app, ma solo caricabili
+> da me e resi disponibili come modelli parametrici all'utente"
+
+Modello di prodotto: **catalogo di cartamodelli parametrici authored in codice dal maintainer;
+l'utente finale inserisce solo le misure e scarica il printable**. È il modello FreeSewing,
+non il modello Seamly (CAD per modellisti) — l'intero Epic B come UI utente decade.
+
+### IN — v1
+
+| Area | Scelta | Note |
+|---|---|---|
+| Misure | Misure individuali via form | Un solo set aggregato di misure per utente, sempre modificabile; niente multisize, niente database misure, niente misure-formula |
+| Motore | Tutto-è-formula (parametrico) | Il motore valuta i modelli parametrici sulle misure utente; è il cuore tecnico anche senza UI di costruzione |
+| Pezzi | Margini, tacche, grainline/interni, etichette: **tutti opzionali** | "tutto opzionale: l'utente sceglie cosa visualizzare nel printable" — layer toggleabili |
+| Visibilità | Gruppi/layer con visibilità | Riletto in chiave consumer: customizzazione di cosa finisce nel printable |
+| Output | **PDF tiled** per stampa casalinga | Multi-pagina A4/Letter con crocini; unico output v1 |
+| Layout | Impaginazione automatica semplice | Pezzi distribuiti sulle pagine senza sovrapposizioni; niente nesting ottimizzato |
+| Pipeline | Authoring pattern in codice (maintainer) | Stile FreeSewing: niente editor visuale da costruire in v1 |
+| Persistenza | Salvataggio misure utente | Le misure persistono e si riapplicano a ogni modello del catalogo |
+
+### OUT (v1)
+
+- CAD di costruzione per l'utente (tutti i 57 tool, dialog, undo di costruzione, history, calcolatrice, variabili)
+- Multisize/grading, database misure note, misure calcolate
+- Nesting ottimizzato su tessuto e piano di taglio configurabile
+- DXF (flat/AAMA/ASTM), PS/EPS, stampa diretta, SVG/PDF a foglio singolo
+- Import/compatibilità .val, XSD, migrazione schemi
+- i18n (hub già all-English), anteprima live durante l'editing misure (non selezionata), auto-update, immagine di sfondo, union, true darts
+
+### Conseguenze sull'analisi degli ostacoli
+
+Con questo scope, degli ostacoli di §2 sopravvivono solo: il motore parametrico (ma senza
+vincolo di fedeltà .val → §2.1 decade), l'offset dei margini (Clipper2), la generazione PDF
+tiled a scala fisica (pdf-lib) e un'impaginazione banale. Gli ostacoli grossi (§2.2 UI CAD,
+XSD, EPS/pdftops, nesting multithread) sono tutti fuori scope. La raccomandazione
+`@freesewing/core` + renderer proprio copre quasi tutto lo scope v1.
+
+---
+
+## 6. FreeSewing e un futuro CAD di costruzione: analisi di compatibilità
+
+> Domanda (2026-07-13): se la v1 nasce sul modello FreeSewing (§5), un'evoluzione futura verso
+> una versione con **CAD di costruzione** (l'utente crea/modifica cartamodelli visualmente,
+> alla Seamly) resta possibile o il modello va stretto?
+> Analisi verificata empiricamente su **@freesewing/core 4.10.0** (MIT) installato e ispezionato.
+
+### 6.1 Il nodo architetturale: pattern-as-code vs pattern-as-data
+
+- In FreeSewing un pattern è **codice**: ogni part ha una funzione `draft()` JS che riceve
+  `{Point, Path, points, paths, measurements, options, macro, sa, …}` e costruisce la geometria
+  imperativamente (verificato in `part.mjs`, `Part.prototype.shorthand`).
+- Un CAD richiede il pattern come **dato**: una lista serializzabile di step di costruzione
+  (è esattamente ciò che è un file .val di Seamly), che si possa editare, annullare, rivalutare.
+
+Quindi un CAD non si costruisce "dentro" il modello di authoring FreeSewing — ma **sopra**:
+si definisce un **op-set dichiarativo proprio** (JSON: `{tipo: "pointAtDistanceAngle", from:
+"A", dist: "waist/4+2", angle: 90, id: "B"}`…) e un **interprete che è un unico design
+FreeSewing generico**: la sua `draft()` legge la lista di op e la esegue chiamando i primitivi
+di core. Il CAD edita il JSON; ogni modifica → re-draft → re-render. Undo/redo = operazioni
+sulla lista, non sul motore.
+
+### 6.2 I primitivi ci sono già (verificato sull'API)
+
+Mappa tool Seamly → primitivi `@freesewing/core` (da `index.mjs`, `point.mjs`, `path.mjs`):
+
+| Famiglia tool Seamly | Primitivo FreeSewing |
+|---|---|
+| Punti derivati (endline, alongline, shift…) | `Point.shift/shiftTowards/shiftFractionTowards/shiftOutwards/rotate/flipX/flipY/translate` |
+| Intersezioni linea/linea, linea/asse | `linesIntersect, beamsIntersect, beamIntersectsX/Y` |
+| Intersezioni con cerchi e tangenti | `circlesIntersect, lineIntersectsCircle, beamIntersectsCircle` |
+| Intersezioni con curve | `curvesIntersect, curveIntersectsX/Y, lineIntersectsCurve, Path.intersects/intersectsX/intersectsY/intersectsBeam` |
+| Taglio di curve (cut arc/spline) | `splitCurve, Path.split/divide/trim, pointOnCurve` |
+| Punto lungo percorso | `Path.shiftAlong/shiftFractionAlong, measureAlong` |
+| Archi | `Path.circleSegment` (approssimazione Bézier), `utils` circle |
+| Margini di cucitura | `Path.offset(distance)` — built-in |
+| Curve spline/Bézier | `Path.curve/curve_/_curve/smurve`, classe `Bezier` (bezier-js) |
+| Specchiature/rotazioni di gruppi | `Path.rotate/translate/reverse`, `flipX/flipY`, `generateStackTransform` |
+| Grainline, tacche, etichette | plugin ufficiali (`plugin-annotations`: title, grainline, notches…) |
+
+La copertura dei 57 tool Seamly a livello *geometrico* è pressoché totale. Manca l'**arco
+ellittico** come primitiva nativa (approssimabile con Bézier) — unico gap geometrico rilevato.
+
+### 6.3 Cosa FreeSewing NON dà (e sarebbe comunque tuo, con qualunque motore)
+
+1. **Parser di formule user-facing**: in FS le espressioni sono JS. Il CAD ha bisogno di un
+   linguaggio formule per l'utente (`waist/4+2`); va scritto/adottato un parser la cui
+   valutazione produce i numeri passati ai primitivi. Pezzo nuovo, ma indipendente dal motore.
+2. **Grafo di dipendenze a livello di punto**: FS traccia dipendenze solo tra *part*
+   (`from`/`after`, `resolvedDependencies`, `draftOrder` — verificato in `pattern-config.mjs`).
+   Il CAD deve sapere "chi referenzia il punto B" (per warning su delete, rename, drag).
+   Siccome l'op-set è un dato tuo, il grafo si ricava banalmente dalle referenze nel JSON.
+3. **Ricalcolo incrementale**: FS ri-drafta tutto a ogni modifica. **Benchmark empirico
+   (Node 22, M-series): Aaron (canotta, 5 part) = ~1,1 ms/draft, ~1,9 ms draft+render SVG.**
+   Anche un pattern 10× più complesso sta comodamente nel budget di un frame (16 ms) →
+   il full re-draft regge perfino il drag interattivo. Il ricalcolo incrementale non serve.
+4. **Editor interattivo** (hit-testing, maniglie, snapping): FS produce SVG statico, ma
+   `asRenderProps()` su Point/Path espone la geometria strutturata per un renderer/editor
+   proprio. Questo era "la parte nuova" fin dalla ricerca iniziale, con o senza CAD.
+
+### 6.4 Lock-in: quanto costa cambiare idea dopo
+
+L'asset strategico è l'**op-set JSON**, che è tuo e engine-agnostic: l'interprete che lo esegue
+su FreeSewing è sottile (una funzione per tipo di op). Se un domani core diventasse limitante,
+si ri-targetta l'interprete su un motore geometrico proprio senza toccare né i file pattern né
+il CAD. FreeSewing è un **backend di esecuzione sostituibile**, non una prigione. (MIT, attivo
+su Codeberg — rischio di abbandono mitigabile con fork/vendoring, è puro JS senza dipendenze
+native.)
+
+### 6.5 Verdetto e raccomandazione
+
+**Sì, il modello FreeSewing è compatibile con l'evoluzione CAD** — a una condizione
+architetturale: **introdurre presto il livello pattern-as-data**. Il rischio non è FreeSewing,
+è accumulare un catalogo di pattern scritti come `draft()` JS libere: quelle non sono
+"liftabili" automaticamente a op-list, e andrebbero riscritte a mano quando arriva il CAD.
+
+Raccomandazione pratica:
+- **v1**: costruire subito il **thin op-interpreter** (costo contenuto: è un `switch` sui tipi
+  di op che chiama i primitivi §6.2) e scrivere i pattern del catalogo **come dati** (op-list
+  JSON/TS tipizzato), non come funzioni draft libere. FreeSewing resta sotto come motore.
+- **v2 (CAD)**: l'editor visuale genera/edita le stesse op-list. Undo, history ("cronologia di
+  costruzione" alla Seamly, feature B12), gruppi di visibilità e formule arrivano naturali
+  perché il formato è già una sequenza di step referenziati.
+- Il parser di formule conviene introdurlo già in v1 solo se i pattern ne beneficiano; altrimenti
+  in v2 (le op-list v1 possono usare espressioni pre-calcolate).
+
+**Verificato**: API core 4.10.0 (primitivi, offset, dipendenze part-level, shorthand,
+asRenderProps), benchmark di draft, licenza MIT. **Inferito**: costo "contenuto"
+dell'interprete, assenza di lib per archi ellittici nativi nell'ecosistema plugin.
+
+---
+
+## 7. Riepilogo verificato / inferito
+
+- **Verificato sul codice**: dimensioni (257k LOC, 57 tool, 46 dialog, 52 undo, 49 schemi XSD,
+  69 traduzioni), uso di Xerces/XSD, `pdftops` via QProcess, `QThreadPool` nel nesting,
+  offset custom `Equidistant`, export AAMA/ASTM, undo basato su DOM XML, ricalcolo via
+  ri-parsing, GPLv3, Qt 6.8/C++14/qmake.
+- **Inferito**: stime di effort, maturità delle alternative JS (Clipper2 JS/WASM, pdf-lib,
+  assenza di lib AAMA JS), comportamento di FreeSewing sulla stampa a scala.

--- a/PLAN-baltici-implementation.md
+++ b/PLAN-baltici-implementation.md
@@ -1,0 +1,421 @@
+# Baltici — Piano d'implementazione
+
+> Piano tecnico per l'area **Baltici** (Splitwise light) dentro `packages/app`.
+> Scope e feature: vedi [PLAN-baltici-splitwise.md](PLAN-baltici-splitwise.md).
+>
+> **Stato:** ✅ **codex-review APPROVED** — piano base (6 finding) + integrazione
+> **InstantDB** (altri 4 finding: refs stale, ordine canonico persistito, permessi
+> `delete=false`+soft-delete, typing env). **D1 RISOLTA → InstantDB** (backend reattivo
+> client-side, no login): §4/§5 hanno rimpiazzato il layer localStorage.
+> ⏳ Implementazione in attesa di via libera + app ID InstantDB.
+>
+> ⚠️ Alcune parti sotto sono state riviste col codex assumendo **localStorage**. Con
+> InstantDB restano validi **motore di calcolo (§3), modello (§2), validazione (§6b),
+> UI (§6), routing/hub (§7)**; sono cambiati **persistenza (§4)** e **store (§5)** — le
+> mitigazioni localStorage (write-queue, decode/version) **non servono più** perché
+> InstantDB gestisce sync/persistenza/concorrenza.
+
+## 0. Scope in una riga
+
+App per 8 persone, **senza login**, per: gestire persone di un gruppo, aggiungere/
+rimuovere spese (split *tutti* / *sottogruppo* / *importi esatti*), e **vedere lo stato
+attuale dei conti** (credito/debito per persona, chi-deve-a-chi semplificato, totale
+vacanza + speso per persona). Nessun settle-up in-app. Persistenza: **InstantDB**
+(backend reattivo client-side, dati condivisi in realtime tra i telefoni, no login).
+
+---
+
+## 1. Principi architetturali
+
+1. **Logica di calcolo = funzioni pure, isolate e testabili.** Nessuna dipendenza da
+   React o dallo storage. Sono il cuore corretto dell'app (saldi, chi-deve-a-chi,
+   semplificazione debiti, arrotondamenti).
+2. **Persistenza = InstantDB, isolata dietro un mapper** (`toGroupState`) + azioni
+   `db.transact`. Il resto dell'app lavora su `GroupState` (§2) senza sapere di
+   InstantDB → se un domani si cambiasse backend, si tocca solo `db.ts` + store.
+3. **Tutti gli importi in centesimi interi** (`number` intero). Mai float per i soldi:
+   si evita `0.1 + 0.2`. Formattazione a €X,XX solo in visualizzazione.
+4. **UI con il design-system** dove copre; piccoli componenti locali (stilati coi token
+   DS) dove il DS non arriva (select, toggle, input numerico).
+5. **Un solo gruppo** (D2). Niente concetto di "utente corrente" (D4): il pagante è
+   sempre scelto esplicitamente.
+
+---
+
+## 2. Modello dati
+
+`packages/app/src/baltici/model.ts`
+
+```ts
+export type PersonId = string;
+export type ExpenseId = string;
+
+export interface Person {
+  id: PersonId;
+  name: string;
+  color: string;        // US-05: avatar/colore (uno da una palette fissa)
+}
+
+export type SplitMode = "equal" | "exact";
+// "equal" copre sia "tutti" (participants = tutte le persone) sia "sottogruppo"
+// (participants = sottoinsieme). "exact" = importi esatti per persona.
+
+// Discriminated union → UNA sola fonte di verità per il "chi divide" (finding #2):
+// - equal: la verità è `participants`.
+// - exact: la verità è `exactShares`; i partecipanti si DERIVANO dalle sue chiavi
+//   (non esiste un `participants` separato da tenere in sync).
+interface ExpenseBase {
+  id: ExpenseId;
+  description: string;
+  amountCents: number;              // totale, intero in centesimi (> 0)
+  payerId: PersonId;                // scelto esplicitamente
+  date: string;                     // "YYYY-MM-DD"
+  createdAt: number;                // Date.now(), per ordinamento stabile
+}
+export interface EqualExpense extends ExpenseBase {
+  splitMode: "equal";
+  participants: PersonId[];         // ≥ 1, unici; ordine non significativo (canonizzato in calc)
+}
+export interface ExactExpense extends ExpenseBase {
+  splitMode: "exact";
+  exactShares: Record<PersonId, number>; // cent per persona, somma === amountCents
+}
+export type Expense = EqualExpense | ExactExpense;
+
+// Helper unico usato ovunque (store, calc, validazione removePerson):
+export function participantsOf(e: Expense): PersonId[];   // equal→participants, exact→keys(exactShares)
+export function personIdsInExpense(e: Expense): PersonId[]; // = [payerId, ...participantsOf(e)] deduplicati
+
+export interface GroupState {
+  version: 1;
+  name: string;                     // es. "Vacanza Baltici 2026"
+  people: Person[];                 // ordine = ordine canonico (vedi calc §3)
+  expenses: Expense[];
+}
+```
+
+Note:
+- Il pagante **può** non essere tra i partecipanti (paga ma non partecipa) → gestito
+  naturalmente: il suo "paid" è comunque conteggiato, la sua quota è 0.
+- **`exact` valido solo se** `Object.keys(exactShares).length ≥ 1`, tutti gli id
+  esistono in `people`, ogni share è intero `≥ 0`, e `sum(shares) === amountCents`.
+- **`equal` valido solo se** `participants.length ≥ 1` e tutti gli id esistono in `people`.
+- **Numero di persone: N flessibile, nessun limite hard-coded** (finding #6). "8" è lo
+  scenario d'uso, non un vincolo: lo store non blocca su 8, i toggle e la palette colori
+  gestiscono N qualsiasi (palette che cicla / genera colori). Nessuna UI assume esattamente 8.
+
+---
+
+## 3. Motore di calcolo (funzioni pure)
+
+`packages/app/src/baltici/calc.ts` — nessun import da React/storage.
+
+```ts
+// Quota dovuta da ciascun partecipante per UNA spesa, in centesimi interi.
+// equal: amount diviso equamente tra i participants. Il resto (1..N-1 cent) è
+//        distribuito 1 cent a testa seguendo l'ORDINE CANONICO (finding #3):
+//        i partecipanti sono ordinati per la loro posizione in `people` (non per
+//        l'ordine dell'array `participants`, che dipende dai toggle). Stesso
+//        sottoinsieme logico ⇒ stessa assegnazione del resto, sempre.
+// exact: ritorna direttamente exactShares.
+// Richiede input valido (vedi validazione §6). Su spesa "equal" con 0 partecipanti
+// è uno stato illegale che la validazione impedisce a monte; calc lancia (fail-fast),
+// non divide per zero.
+export function shareOf(expense: Expense, people: Person[]): Record<PersonId, number>;
+
+// Saldo netto per persona su TUTTE le spese, in centesimi.
+// net = somma(anticipato come payer) − somma(quote dovute).
+// > 0 = in credito (il gruppo gli deve), < 0 = in debito.
+export function balances(state: GroupState): Record<PersonId, number>;
+
+// US-24: totale speso (come payer) per persona + totale complessivo gruppo.
+export function totals(state: GroupState): {
+  perPerson: Record<PersonId, number>;
+  grand: number;
+};
+
+// US-21 + US-22: dai saldi netti, lista minima di pagamenti "X → Y : importo"
+// (greedy min-cash-flow: match del maggior creditore col maggior debitore).
+export interface Settlement { fromId: PersonId; toId: PersonId; amountCents: number; }
+export function simplifyDebts(net: Record<PersonId, number>): Settlement[];
+```
+
+**Correttezza da garantire (invarianti testabili):**
+- Per ogni spesa, `sum(shareOf) === amountCents` (nessun cent perso/creato).
+- `sum(balances) === 0` sempre.
+- `sum(settlement.amount)` coerente; ogni saldo azzerato dalla lista dei pagamenti.
+- Arrotondamento deterministico (stesso input → stesso output, no `Math.random`).
+
+Questi diventano **unit test** (vitest) — vedi §9.
+
+---
+
+## 4. Persistenza — InstantDB (D1 risolta)
+
+Dipendenza: `@instantdb/react`. Config in `packages/app/src/baltici/db.ts`:
+
+```ts
+import { init, i } from "@instantdb/react";
+
+// app ID pubblico → env var al build Netlify (come i VITE_ di Telegram)
+const APP_ID = import.meta.env.VITE_INSTANT_APP_ID;
+
+const schema = i.schema({
+  entities: {
+    people: i.entity({
+      name: i.string(),
+      color: i.string(),
+      createdAt: i.number(),      // FINDING #2: ordine canonico PERSISTITO (per §3).
+                                  // toGroupState ordina people per createdAt — mai
+                                  // per l'ordine di ritorno della query (non garantito).
+    }),
+    expenses: i.entity({
+      description: i.string(),
+      amountCents: i.number(),
+      payerId: i.string(),        // id di una row `people`
+      date: i.string(),           // "YYYY-MM-DD"
+      splitMode: i.string(),      // "equal" | "exact"
+      participants: i.json(),     // PersonId[] (solo equal)
+      exactShares: i.json(),      // Record<PersonId, number> (solo exact)
+      createdAt: i.number(),
+      deleted: i.boolean(),       // FINDING #3: soft-delete (US-31). La rimozione è un
+                                  // update deleted=true, non un delete distruttivo →
+                                  // dato recuperabile, resistente a cancellazioni
+                                  // accidentali/malevole. toGroupState filtra i deleted.
+    }),
+    meta: i.entity({ groupName: i.string() }), // singola row
+  },
+});
+
+export const db = init({ appId: APP_ID, schema });
+export type DbSchema = typeof schema;
+```
+
+Note:
+- **Namespace vs GroupState:** i dati vivono in InstantDB come entità (`people`,
+  `expenses`, `meta`); il `GroupState` del §2 è la **vista in memoria** ricomposta dalla
+  query (people ordinate → ordine canonico per §3). `exactShares`/`participants` restano
+  la union del §2, serializzati come campi `i.json()`.
+- **Permessi (no login) + mitigazioni rischio (finding #3):** l'app ID è nel bundle,
+  quindi "aperto" significa *scrivibile da chiunque carichi il sito*, non solo da chi ha
+  il link. Rischio accettato per dati di vacanza a basso valore, **ma** mitigato:
+  - **niente hard-delete:** permessi `view/create/update = "true"`, **`delete = "false"`**
+    su tutte le entità → nessuna cancellazione distruttiva possibile; la rimozione spese
+    è soft (`deleted=true`), i dati restano recuperabili.
+  - **app ID separati per ambiente** (dev vs prod) → i test non toccano i dati reali.
+  - **backup/restore** via dashboard InstantDB se qualcosa va storto.
+  - documentato come **intenzionalmente pubblico e a basso rischio** (piccolo blast
+    radius: un solo gruppo-vacanza).
+  Configurazione in dashboard o `instant.perms.ts`. (D4: nessuna auth.)
+- **id:** li genera InstantDB (`id()` / `db.transact`), non serve `crypto.randomUUID()`.
+- **Typing env (finding #4):** aggiungere `VITE_INSTANT_APP_ID: string` a
+  `packages/app/src/vite-env.d.ts` (oggi dichiara solo le due var Telegram), altrimenti
+  `import.meta.env.VITE_INSTANT_APP_ID` non è tipato sotto la config TS attuale.
+- **Cosa NON serve più** (rispetto alla vecchia impl. localStorage): interfaccia
+  `BalticiRepository`, `decodeGroupState`/versioning (finding #4), write-queue
+  serializzata (finding #1). InstantDB gestisce sync, persistenza, offline e ordine
+  delle scritture lato servizio. *(La validazione della shape resta utile solo in forma
+  “difensiva” leggera nel mapping query→GroupState.)*
+
+> **Gancio D1:** quando si sceglie l'architettura dati, si aggiunge
+> `supabaseRepository.ts` (stessa interfaccia) e si cambia **una riga** nel provider.
+> Calcolo e UI restano identici.
+
+---
+
+## 5. Store (stato applicativo)
+
+`packages/app/src/baltici/store.tsx` — hook **reattivo** su InstantDB (niente Redux,
+niente Context di stato: la reattività la dà InstantDB).
+
+- **Lettura live.** `db.useQuery({ people: {}, expenses: {}, meta: {} })` restituisce i
+  dati in realtime. Un mapper puro `toGroupState(queryResult): GroupState` li ricompone
+  nella vista del §2:
+  - **people ordinate per `people.createdAt`** → ordine canonico stabile e persistito
+    (finding #2), MAI l'ordine di ritorno della query;
+  - **expenses filtrate** su `deleted !== true` (finding #3), poi mappate alla union
+    `Equal|Exact`.
+  Il resto dell'app lavora su `GroupState`, ignaro di InstantDB.
+- **Derivati memoizzati** (`useMemo` su `GroupState`): `balances`, `totals`,
+  `simplifyDebts` — ricalcolati quando la query cambia. Identici a prima.
+- **Scritture:** `db.transact(...)` con le azioni:
+  - persone: `addPerson` (setta `createdAt`), `renamePerson`, `removePerson`,
+  - spese: `addExpense` (setta `createdAt`, `deleted=false`), `updateExpense`,
+    `removeExpense` = **update `deleted=true`** (soft-delete, finding #3; nessun hard-delete),
+  - gruppo: `setGroupName` (update della row `meta`).
+  InstantDB serializza/ordina le scritture lato servizio e propaga in realtime → **niente
+  write-queue** (l'ex finding #1 non si applica più). Update ottimistico è nativo.
+- **StrictMode:** con `useQuery`/`transact` il doppio-mount in dev è innocuo (nessun
+  `load/save` manuale idempotente da gestire).
+- `removePerson` **bloccante** (T2): prima della `transact` di delete, si controlla in
+  memoria (su `GroupState`) se la persona compare in **qualsiasi** spesa come pagante
+  **o** partecipante **o** chiave di `exactShares`. Il check usa `personIdsInExpense(e)`
+  (include le chiavi di `exactShares`) → nessun riferimento sfugge (finding #2). Se
+  coinvolta → si blocca con messaggio, niente transact.
+
+Gli id delle row li genera InstantDB (helper `id()` dell'SDK), non `crypto.randomUUID()`.
+
+---
+
+## 6. UI — pagine e componenti
+
+Pattern: layout con `<Outlet/>` come `TerrariumLayout`, pagine che usano il DS +
+componenti locali. **Nessun provider di stato**: `db` è un singleton di modulo (`db.ts`)
+e le pagine leggono/scrivono chiamando l'hook `useBaltici()` (che dentro usa
+`db.useQuery`/`db.transact`). La condivisione dello stato tra pagine la garantisce la
+reattività di InstantDB, non un Context.
+
+### Pagine (`packages/app/src/pages/baltici/`)
+| File | Route | Contenuto | Stories |
+|---|---|---|---|
+| `BalticiHome.tsx` | `/baltici` (index) | Riepilogo: saldi per persona (credito/debito), totale vacanza, link alle altre viste | US-20, US-24 |
+| `BalticiExpenses.tsx` | `/baltici/expenses` | Lista spese ordinata per data + bottone "aggiungi"; ogni riga con rimuovi/modifica | US-30, US-31 |
+| `BalticiAddExpense.tsx` | `/baltici/expenses/new` (+ `/:id/edit`) | Form aggiungi/modifica spesa | US-10..13, US-31 |
+| `BalticiSettleUp.tsx` | `/baltici/who-owes` | Chi-deve-a-chi semplificato (sola lettura) | US-21, US-22 |
+| `BalticiPeople.tsx` | `/baltici/people` | Gestione persone (+ nome gruppo) | US-01, US-02, US-03, US-05 |
+
+### Componenti locali (`packages/app/src/baltici/components/`)
+DS non ha questi → li costruiamo (stilati coi token DS `var(--...)`):
+- `PersonSelect` — dropdown "ha pagato" (native `<select>` stilizzata).
+- `ParticipantsToggle` — griglia toggle per le N persone (US-11/12), con scorciatoia "tutti".
+- `AmountInput` — input importo → centesimi. Vedi regole di parsing sotto.
+- `ExactSharesEditor` — un `AmountInput` per persona con badge "resto: €X" (US-13).
+- `SplitModeTabs` — segmented `Tutti | Sottogruppo | Importi esatti` (usare DS `Tabs`
+  se adatto, altrimenti locale).
+- `PersonAvatar` — cerchio con iniziale + colore (US-05).
+- `BalanceRow` / `MoneyText` — riga saldo + formattazione €.
+
+### Layout
+`packages/app/src/layouts/BalticiLayout.tsx` — copia di `TerrariumLayout`: link "←
+GORLIUM HUB", `Header` con le tab Baltici (Home / Spese / Chi deve a chi / Persone),
+`<Outlet/>`. Nessun provider da avvolgere (vedi sopra: `db` è un singleton di modulo).
+
+---
+
+## 6b. Validazione (input importi e spese) — finding #5
+
+Nessun pattern di input monetario esiste nel repo/DS → va definito qui.
+
+**`AmountInput` — parsing importo → centesimi interi** (`parseAmountToCents`):
+- Accetta virgola **o** punto come separatore decimali (`12,50` e `12.50` → `1250`).
+- Ignora spazi; opzionale separatore migliaia; max 2 decimali (i decimali extra → errore
+  o troncati, da fissare: **errore** per non nascondere input sbagliati).
+- **Rifiuta**: vuoto, non-numerico, negativo, **zero** → l'importo dev'essere `> 0`.
+- Ritorna `{ cents: number } | { error: string }`; il form mostra l'errore inline e
+  disabilita il salvataggio finché non è valido.
+
+**Validazione spesa a monte del `save` (`validateExpense`)** — impedisce stati illegali:
+- `amountCents > 0`, `payerId` esiste, `date` valida.
+- `equal`: `participants.length ≥ 1`, id unici ed esistenti → così `shareOf` non divide
+  mai per zero.
+- `exact`: chiavi esistenti, ogni share intero `≥ 0`, **`sum(shares) === amountCents`**
+  (l'editor mostra il "resto" e blocca finché non è 0).
+- La stessa `validateExpense` è riusata dalle **azioni dello store** (guardia prima di
+  `db.transact`, così non si scrivono spese illegali) e dagli **unit test**.
+
+## 7. Routing & Hub
+
+**`App.tsx`** — aggiungere sotto il blocco terrariums:
+```tsx
+<Route path="/baltici" element={<BalticiLayout />}>
+  <Route index element={<BalticiHome />} />
+  <Route path="expenses" element={<BalticiExpenses />} />
+  <Route path="expenses/new" element={<BalticiAddExpense />} />
+  <Route path="expenses/:id/edit" element={<BalticiAddExpense />} />
+  <Route path="who-owes" element={<BalticiSettleUp />} />
+  <Route path="people" element={<BalticiPeople />} />
+</Route>
+```
+
+**`Hub.tsx:40`** — trasformare la tile `maglia`:
+```tsx
+{ slug: "baltici", name: "Baltici", accent: "#cc7a4f",
+  desc: "Trip expenses, split fair.", img: "/gorlium/maglia.svg",
+  href: "/baltici", restricted: false },
+```
+(D5: si riusa `maglia.svg` per ora; `href` non-null → tile attiva. `desc` in EN come il
+resto del hub.)
+
+---
+
+## 8. i18n
+
+Aggiungere `translation.baltici.*` e le voci `header.*` per le tab in
+`packages/app/src/locales/en.json`. Tutte le stringhe in **inglese** (coerenza col
+resto). Il tipo di `t()` è generato da `i18next.d.ts` → nuove chiavi tipizzate in
+automatico. *(Nota: i **dati** utente — nomi persone, descrizioni spese — sono runtime,
+non i18n.)*
+
+---
+
+## 9. Testing
+
+- **Unit (vitest)** su `calc.ts` + validazione + mapper `toGroupState` — la parte a rischio:
+  - split equal con resto non divisibile (es. €10 tra 3 → 3,34/3,33/3,33, somma 10,00);
+  - **ordine canonico del resto (finding #3):** lo stesso sottoinsieme passato con
+    `participants` in ordini diversi produce **la stessa** assegnazione del resto;
+  - pagante escluso dai partecipanti;
+  - `sum(balances) === 0` su scenari casuali;
+  - `simplifyDebts` azzera tutti i saldi e non crea pagamenti negativi;
+  - `parseAmountToCents`: `12,50`/`12.50`→1250; vuoto/negativo/zero/3-decimali → errore;
+  - `validateExpense`: equal con 0 partecipanti → invalido; exact con somma ≠ totale →
+    invalido;
+  - `toGroupState`: mapping query InstantDB → `GroupState` (people ordinate = ordine
+    canonico; expenses → union corretta; row con campi mancanti gestite in modo difensivo).
+- *(Nota: vitest non è ancora nel repo → va aggiunto come devDependency in
+  `packages/app`, con script `test`. Da confermare: OK aggiungerlo?)*
+- **Verifica manuale** nel browser (preview) sullo scenario "paghi €120, tutti, 8
+  persone → +€105 / −€15 ×7", e su un caso sottogruppo.
+
+---
+
+## 10. Ordine di lavoro (incrementale, sempre verde)
+
+1. **Modello + calcolo + test** (`model.ts`, `calc.ts`, test). Nessuna UI: si valida la
+   correttezza per prima.
+2. **InstantDB + store reattivo** (`db.ts` schema/init, permessi con `delete="false"`,
+   `store.tsx` con `useQuery`/`transact` + mapper `toGroupState`). Setup app InstantDB +
+   `VITE_INSTANT_APP_ID` (Netlify + `.env` locale) + riga in `vite-env.d.ts`.
+3. **Attivazione area**: `Hub.tsx` (tile), `App.tsx` (route), `BalticiLayout.tsx`,
+   `BalticiHome.tsx` minima → l'area si apre e mostra "stato vuoto".
+4. **Persone** (`BalticiPeople.tsx` + `PersonAvatar`, `PersonSelect`) → si popolano gli 8.
+5. **Aggiungi spesa** (`BalticiAddExpense.tsx` + componenti split) → il flusso completo.
+6. **Lista + rimozione/modifica** (`BalticiExpenses.tsx`).
+7. **Saldi & chi-deve-a-chi** (`BalticiHome` completa, `BalticiSettleUp.tsx`).
+8. **i18n**, rifiniture, responsive (mobile: l'app si userà da telefono).
+
+Ogni step chiude con `pnpm --filter @gorlium/app typecheck` verde.
+
+---
+
+## 10b. Note di implementazione (deviazioni emerse)
+
+Scoperte durante lo sviluppo, recepite nel codice:
+
+1. **`init()` di InstantDB lancia in modo sincrono** se l'app ID non è un UUID valido
+   (verificato: "…is not a valid uuid"). Siccome `db.ts` è importato all'avvio (App →
+   BalticiLayout → db), un app ID malformato manderebbe in blank **tutto il sito**. →
+   `db.ts` inizializza in modo difensivo (`createDb()` in try/catch): in caso di
+   fallimento `db = null`, `isConfigured = false`, l'area mostra "non configurato" e il
+   resto del sito continua a funzionare. In più, `<ErrorBoundary>` attorno all'`<Outlet/>`
+   di Baltici come difesa in profondità. Verificato in browser (hub + gate ok con id non valido).
+2. **Soft-delete anche sulle persone.** Dato che i permessi vietano l'hard-delete su
+   tutte le entità (`delete="false"`), anche `people` ha un campo `deleted`; `removePerson`
+   fa update `deleted=true` (solo se non referenziata — blocco T2 invariato). `toGroupState`
+   filtra le persone `deleted`.
+3. **Storage dei campi split.** Ogni riga spesa memorizza sia `participants` sia
+   `exactShares` (equal → `exactShares={}`, exact → `participants=[]`); `toGroupState`
+   ricostruisce la union in base a `splitMode`.
+
+## 11. Decisioni tecniche (confermate)
+
+- **T1 — vitest:** ✅ **Sì.** Aggiungere vitest come devDependency a `packages/app` con
+  script `test`, e coprire `calc.ts` con gli unit test di §9.
+- **T2 — `removePerson` con spese collegate:** ✅ **Bloccare.** Se la persona è pagante o
+  partecipante di almeno una spesa, la rimozione è vietata con messaggio esplicativo.
+  (Prima si cancellano/modificano le spese che la coinvolgono.)
+- **T3 — D1 (persistenza condivisa):** ✅ **InstantDB** (deciso). Backend reattivo
+  client-side, no login, realtime tra i telefoni. Serve creare l'app su InstantDB e
+  impostare `VITE_INSTANT_APP_ID` su Netlify + permessi "aperti".
+- **T4 — branch/PR:** su branch dedicato `feat/baltici` + PR (come i lavori precedenti).
+  ⏳ **Implementazione in attesa di via libera** (piano prima validato col codex).

--- a/PLAN-baltici-splitwise.md
+++ b/PLAN-baltici-splitwise.md
@@ -1,0 +1,297 @@
+# Baltici — Splitwise light dentro Gorlium
+
+> Obiettivo: una versione **leggera di Splitwise** per regolare i conti durante una
+> vacanza tra 8 persone (tu + 7 amici). Vive come nuova "area" **`baltici`** del hub,
+> rimpiazzando la tile disabilitata **`maglia` / "Knitting & Crochet"**.
+>
+> **Come usare questo documento:** ogni feature è una user story con un ID.
+> Segna con `[x]` quelle che vuoi. Ci sono tre livelli suggeriti (MVP / Consigliate /
+> Extra). Alla fine c'è una sezione **Decisioni aperte** da chiudere prima di implementare.
+
+---
+
+## ✅ Selezione finale (2026-07-19)
+
+Feature confermate per l'implementazione:
+
+**Gruppo & persone** — US-01 (crea gruppo), US-02 (aggiungi persone), US-03
+(modifica/rimuovi persona), US-05 (avatar/colore). → **Un solo gruppo** (D2: no US-04).
+
+**Spese** — US-10 (aggiungi spesa: importo/descrizione/pagante/data), US-11 (split
+parti uguali), US-12 (split su sottoinsieme), US-13 (split per importi esatti).
+→ **Nessun extra**: niente categorie, foto, multi-valuta, grafici, più paganti,
+split % o per articoli.
+
+**Saldi** — US-20 (saldo per persona: credito/debito), US-21 (chi-deve-a-chi), US-22
+(semplificazione debiti), US-24 (totale vacanza + speso per persona). → **Solo
+visualizzazione dello stato attuale**, derivato dalle spese: niente registrazione
+pagamenti (**US-23 settle up esclusa** — i saldi si regolano tra le persone a fine
+vacanza, fuori dall'app).
+
+**Storico** — US-30 (lista spese, ordinabile per data), US-31 (aggiungi/modifica/rimuovi
+spesa). → **US-32 (feed attività) esclusa**: ridondante con la lista spese.
+
+**Dati** — US-40 (persistenza locale). → US-41/42/43 esclusi per ora; **D1
+(architettura dati) rimandata**.
+
+**Area (D5)** — nome **"Baltici"**, per ora **riuso `maglia.svg`** (icona dedicata dopo).
+
+### ⚠️ Vincoli semantici confermati (importanti)
+
+- **Nessun login / nessun "utente corrente" (D4: niente auth).** L'app non sa chi sta
+  inserendo una spesa. → Il pagante va **sempre scelto esplicitamente** dalla lista
+  (nessun default "Tu"); non esiste il concetto di "me". Chiunque apra l'app vede e
+  modifica gli stessi dati.
+- **I saldi sono solo derivati e in sola lettura.** Mostrano lo stato attuale
+  (credito/debito per persona + chi-deve-a-chi semplificato). Non si registrano
+  pagamenti nell'app.
+- **Pagante incluso nella divisione, ma deselezionabile** (in "tutti" è incluso; in
+  "sottogruppo" è pre-selezionato ma togglabile).
+- **Arrotondamenti:** split calcolato in centesimi, lo scarto (1-2 cent) assegnato a una
+  persona così la somma delle quote fa sempre esattamente il totale.
+
+**Escluse:** US-04, US-14, US-15, US-16, US-17, US-23, US-32, US-33, US-41, US-42,
+US-43, US-50, US-51, US-52, US-53, US-54.
+
+> ⏸️ Resta aperta solo **D1** (dove vivono i dati) — vedi
+> [Architettura dati (D1)](#architettura-dati-d1). Nota: senza login, con backend
+> condiviso (D1-A/C) chiunque abbia il link vede/modifica i dati. Nota su US-32 (feed
+> attività): senza "utente corrente" il feed è una cronologia delle spese
+> aggiunte/rimosse (non "chi" le ha toccate).
+
+---
+
+## Contesto tecnico (dallo stato attuale del repo)
+
+Cose importanti che condizionano lo scope:
+
+- **Nessun backend, nessun database.** Oggi l'app è 100% front-end (Vite + React).
+  L'unica chiamata di rete è il form contatti verso Telegram. → La persistenza dei
+  dati è una **decisione da prendere** (vedi *Decisioni aperte* D1).
+- **Nessuno stato globale** (no Redux/Zustand): solo `useState` locale. Per Baltici
+  servirà introdurre un piccolo store (Context o libreria leggera).
+- **Design system "brutalista"** già disponibile (`@gorlium/design-system`): `Stack`,
+  `Card`, `Button`, `TextField`, `Form`, `Tabs`, `Badge`, `Header`, `Callout`… → le
+  useremo per la UI delle pagine, come fa l'area *terrariums*.
+- **i18n** tutto in inglese (`locales/en.json`). Le stringhe di Baltici andranno lì.
+- La tile `maglia` è oggi **disabilitata** (`href: null`): basta ripuntarla a
+  `/baltici` per attivare l'area.
+
+---
+
+## Legenda priorità
+
+- 🟢 **MVP** — il minimo per regolare i conti della vacanza. Senza questo l'app non serve.
+- 🟡 **Consigliata** — migliora molto l'esperienza, poco costo aggiuntivo.
+- 🔵 **Extra** — bello da avere, ma opzionale / più costoso.
+
+---
+
+## 1. Gruppo & persone
+
+- [x] **US-01** 🟢 Come utente, voglio **creare un gruppo** (es. "Vacanza Baltici 2026")
+      con un nome, così tutte le spese vivono in un contesto.
+- [x] **US-02** 🟢 Come utente, voglio **aggiungere le persone** del gruppo (i miei 7
+      amici + me, con un nome ciascuno), così posso assegnare le spese.
+- [x] **US-03** 🟡 Come utente, voglio **modificare/rimuovere una persona**, così correggo
+      errori di battitura o chi si aggiunge/lascia in corsa.
+- [ ] **US-04** 🔵 Come utente, voglio **più gruppi** (es. una vacanza diversa), così
+      riuso l'app in futuro. *(Se no: un solo gruppo hardcoded, più semplice.)*
+- [x] **US-05** 🔵 Come persona, voglio un **avatar/colore** per ognuno, così i conti
+      si leggono a colpo d'occhio.
+
+## 2. Registrare le spese
+
+- [x] **US-10** 🟢 Come utente, voglio **aggiungere una spesa** con importo, descrizione,
+      **chi ha pagato** e **data**, così la registro sul momento.
+- [x] **US-11** 🟢 Come utente, voglio **dividere la spesa in parti uguali** tra tutti,
+      così nel caso più comune non devo fare calcoli.
+- [x] **US-12** 🟢 Come utente, voglio **dividere tra un sottoinsieme** di persone (es.
+      solo chi era a cena), così le spese non riguardano sempre tutti.
+- [x] **US-13** 🟡 Come utente, voglio **dividere per importi esatti** (a X tot, a Y tot),
+      così gestisco i casi in cui le quote non sono uguali.
+- [ ] **US-14** 🟡 Come utente, voglio **dividere per quote/percentuali** (es. 2 quote a
+      chi ha la stanza doppia), così modello divisioni non uniformi in modo rapido.
+- [ ] **US-15** 🔵 Come utente, voglio assegnare una **categoria** (cibo, alloggio,
+      trasporti…), così vedo dove sono andati i soldi.
+- [ ] **US-16** 🔵 Come utente, voglio **allegare una nota / foto dello scontrino**, così
+      ho traccia del giustificativo. *(La foto richiede storage → vedi D1.)*
+- [ ] **US-17** 🔵 Come utente, voglio registrare **"più persone hanno pagato"** una spesa
+      unica, così gestisco pagamenti condivisi.
+
+## 3. Saldi & chi deve a chi
+
+- [x] **US-20** 🟢 Come utente, voglio vedere il **saldo di ogni persona** (in positivo /
+      in negativo), così so a colpo d'occhio chi è avanti e chi indietro.
+- [x] **US-21** 🟢 Come utente, voglio vedere **chi deve quanto a chi**, così sappiamo
+      concretamente i pagamenti da fare.
+- [x] **US-22** 🟡 Come utente, voglio la **semplificazione dei debiti** (minimo numero di
+      transazioni), così invece di 20 bonifici incrociati ne facciamo pochi.
+- [ ] **US-23** ⛔ ~~Registrare un pagamento / "settle up"~~ — **ESCLUSA**: i saldi si
+      regolano tra le persone a fine vacanza, fuori dall'app. In-app solo visualizzazione.
+- [x] **US-24** 🔵 Come utente, voglio un **totale complessivo della vacanza** e quanto ha
+      speso in totale ciascuno, così ho il quadro finale.
+
+## 4. Storico & modifiche
+
+- [x] **US-30** 🟢 Come utente, voglio **vedere la lista di tutte le spese** (con importo,
+      pagante, data), così controllo cosa è stato inserito.
+- [x] **US-31** 🟢 Come utente, voglio **modificare o cancellare una spesa**, così correggo
+      gli errori.
+- [ ] **US-32** ⛔ ~~Feed attività~~ — **ESCLUSA**: ridondante con la lista spese (US-30),
+      già ordinabile per data e con aggiungi/rimuovi. Senza login non c'è il "chi".
+- [ ] **US-33** 🔵 Come utente, voglio **cercare/filtrare** le spese (per persona,
+      categoria, data), così ritrovo velocemente una voce.
+
+## 5. Condivisione dei dati tra gli 8 (⚠️ dipende da D1)
+
+> Questo blocco è il vero bivio architetturale. Senza backend, i dati restano **solo
+> sul tuo browser** e gli altri non li vedono.
+
+- [x] **US-40** 🟢 Come utente, voglio che i dati **restino salvati** anche se chiudo e
+      riapro l'app (persistenza locale nel browser).
+- [ ] **US-41** 🟡 Come gruppo, vogliamo **vedere e modificare gli stessi dati** dai nostri
+      telefoni in tempo (quasi) reale, così ognuno inserisce le proprie spese.
+      *(Richiede un backend o un servizio dati esterno → D1.)*
+- [ ] **US-42** 🔵 Come utente, voglio **esportare** i conti (CSV / testo da incollare in
+      chat), così condivido il riepilogo anche senza sync.
+- [ ] **US-43** 🔵 Come utente, voglio **importare/ripristinare** i dati da un file, così
+      posso fare backup e passaggio manuale tra dispositivi.
+
+## 6. Extra & rifiniture
+
+- [ ] **US-50** 🔵 **Multi-valuta** (spese in EUR e valuta locale baltica con tasso di
+      cambio), così gestisco spese fatte in valute diverse.
+- [ ] **US-51** 🔵 **Grafico spese** per categoria o per persona, così visualizzo la spesa.
+- [ ] **US-52** 🔵 **Spese ricorrenti** (es. affitto casa diviso per notti), così non le
+      reinserisco.
+- [ ] **US-53** 🔵 **Split per articoli** (dividi lo scontrino voce per voce), così i conti
+      del supermercato sono precisi.
+- [ ] **US-54** 🔵 **Modalità offline / PWA installabile sul telefono**, così la uso comoda
+      durante la vacanza senza connessione.
+
+---
+
+## Set consigliato per la vacanza (proposta)
+
+Un MVP realistico e utile in vacanza, se i dati restano **sul tuo dispositivo**
+(tu tieni i conti per tutti):
+
+> US-01, US-02, US-10, US-11, US-12, US-13, US-20, US-21, US-22, US-23, US-30,
+> US-31, US-40, US-42
+
+Se invece volete che **ognuno inserisca le proprie spese dal suo telefono** (US-41),
+serve prima chiudere D1 con una scelta di backend.
+
+---
+
+## Decisioni aperte (da chiudere prima di implementare)
+
+- **D1 — Dove vivono i dati? → ✅ DECISO: InstantDB** (backend-as-a-service reattivo,
+  client-side, no login). Motivi: read/write anonimi (regola permessi `"true"`), SDK
+  `@instantdb/react` su Vite senza server, **realtime + offline inclusi**, app ID
+  pubblico via `VITE_*` (come Telegram), free tier "free forever". Dettagli e confronto
+  con le alternative: [Architettura dati (D1)](#architettura-dati-d1).
+- **D2 — Un solo gruppo o più gruppi?** (US-04) Un solo gruppo semplifica molto tutto.
+- **D3 — Multi-valuta sì/no?** (US-50) Se le spese sono tutte in EUR, si taglia.
+- **D4 — Autenticazione? → ✅ DECISO: nessuna.** App "aperta": chiunque abbia il link
+  vede/modifica i conti (permessi InstantDB `read/write = "true"`). Rischio accettabile
+  per un gruppo-vacanza privato; l'app ID è comunque pubblico by design.
+- **D5 — Nome dell'area:** confermi **"Baltici"** come label della tile? E vuoi anche una
+  nuova icona SVG (`/gorlium/baltici.svg`) al posto di `maglia.svg`?
+
+---
+
+## Architettura dati (D1)
+
+> ✅ **DECISO: InstantDB** (opzione E). Sotto: la scelta e il confronto con le
+> alternative valutate.
+
+### ✅ Scelta: E. InstantDB — backend reattivo, client-side, no login (verificato)
+
+- Nuove dipendenze: **1** → `@instantdb/react` (usabile anche vanilla).
+- Init `init({ appId, schema })`; **app ID pubblico** → in `VITE_INSTANT_APP_ID`
+  (stesso pattern env-var di Telegram). Nessun server, gira su Vite/React client-side.
+- **No login:** permessi permissivi; si abilita read/write anonimi con regola `"true"`.
+- **Realtime + offline inclusi** (sync live tra i telefoni, cache offline).
+- Free tier "free forever", nessun pause, uso commerciale ok, no carta.
+- Impatto sul piano tecnico: sostituisce lo store `load/save` + write-queue con modello
+  reattivo (`useQuery`/`transact`) → **elimina** le mitigazioni localStorage (write-queue
+  finding #1, decode/version finding #4); aggiunge schema InstantDB + regole permessi.
+  Motore di calcolo e UI **invariati**. Dettagli in `PLAN-baltici-implementation.md`.
+- Unico neo: prodotto **relativamente giovane** (dipendenza da un servizio recente).
+
+### Alternative valutate (non scelte)
+
+### Stato attuale del repo (verificato)
+
+- `packages/app` dipende **solo** da: react, react-dom, react-router-dom, i18next &
+  co. **Nessuna dipendenza dati** (no db, no client di storage).
+- `netlify.toml` contiene **solo** il redirect SPA (`/* → /index.html`). **Nessuna
+  Netlify Function**, nessuna cartella `netlify/`.
+- Precedente utile: il form contatti (`Contacts.tsx`) parla con un servizio esterno
+  (Telegram) **direttamente dal browser** usando env var `VITE_*` iniettate da Netlify
+  al build. → Lo stesso identico pattern vale per un DB client-side.
+
+Conseguenza: per **condividere** i dati tra gli 8 serve un servizio dati ospitato
+(non può vivere dentro la SPA). Quanto si tocca la struttura di gorlium dipende
+dall'opzione.
+
+### Opzioni
+
+**A. Supabase — Postgres gestito, client dal browser** 🟢 *(più leggera per DB condiviso)*
+- Nuove dipendenze: **1** → `@supabase/supabase-js`.
+- Modifiche a gorlium: **minime** — resta una SPA. Si aggiunge un modulo dati
+  (`src/baltici/data.ts`) + 2 env var Netlify (`VITE_SUPABASE_URL`,
+  `VITE_SUPABASE_ANON_KEY`), **stesso pattern di Telegram**. Build/deploy invariati.
+- Infra esterna: account Supabase (free tier) + creare le tabelle.
+- Sync tra telefoni: **realtime ✅**.
+
+**B. Netlify Blobs / Functions — dentro l'host attuale**
+- Nuove dipendenze: 1–2 (`@netlify/blobs`, event. `@netlify/functions`).
+- Modifiche a gorlium: **medie** — introduce `netlify/functions/`, la SPA non è più
+  "solo statica", va configurato il build delle functions in `netlify.toml`.
+- Infra esterna: nessun terzo account (è Netlify, già in uso).
+- Sync: **polling** (niente realtime automatico). Blobs = key-value, ottimo per un
+  singolo JSON di gruppo.
+
+**C. Firebase Firestore — client dal browser**
+- Nuove dipendenze: 1 (`firebase`, pacchetto più pesante).
+- Modifiche a gorlium: minime (come A). Infra: account Firebase (free tier).
+- Sync: **realtime ✅**. API più verbose di Supabase.
+
+**D. Solo localStorage — nessuna condivisione**
+- Nuove dipendenze: **0**. Modifiche: **nessuna** (persistenza browser).
+- Sync: **❌**. I dati stanno solo sul tuo browser → **una persona tiene i conti**.
+- Abbinabile a esporta/importa (US-42/US-43) per una sync manuale.
+
+### Confronto sintetico
+
+| Opzione | Nuove dipendenze | Modifiche a gorlium | Sync tra telefoni | Infra |
+|---|---|---|---|---|
+| **A. Supabase** | 1 | minime (come Telegram) | realtime ✅ | account free |
+| **B. Netlify Blobs** | 1–2 | medie (functions + toml) | polling | incluso Netlify |
+| **C. Firebase** | 1 (pesante) | minime | realtime ✅ | account free |
+| **D. localStorage** | 0 | nessuna | ❌ | zero |
+
+**Indicazione:** se serve che **ognuno inserisca dal proprio telefono** → **A (Supabase)**
+è la più leggera. Se basta che **una persona tenga i conti** → **D (localStorage)**,
+eventualmente + export per condividere il riepilogo.
+
+*(Nota: la logica di calcolo — saldi, chi-deve-a-chi, semplificazione debiti — è
+identica in tutte le opzioni. Cambia solo il layer di persistenza, isolabile dietro
+un'unica interfaccia dati: si può partire con D e migrare ad A senza riscrivere la UI.)*
+
+---
+
+## Nota di implementazione (per dopo la selezione)
+
+Riepilogo di cosa si tocca, così è chiaro lo scope:
+1. `packages/app/src/pages/Hub.tsx` — ripuntare la tile `maglia` → `baltici` (`href: "/baltici"`).
+2. `packages/app/src/App.tsx` — aggiungere il sotto-albero di route `/baltici`.
+3. `packages/app/src/layouts/BalticiLayout.tsx` — nuovo layout (sul modello di `TerrariumLayout`).
+4. `packages/app/src/pages/Baltici*.tsx` — le pagine (lista spese, aggiungi spesa, saldi…).
+5. Logica di calcolo saldi + semplificazione debiti (funzioni pure, testabili).
+6. Store dati + persistenza (secondo D1).
+7. `packages/app/src/locales/en.json` — stringhe.
+8. `packages/app/public/gorlium/baltici.svg` — icona (secondo D5).

--- a/PLAN-tailoring-app.md
+++ b/PLAN-tailoring-app.md
@@ -1,0 +1,127 @@
+# PLAN — Tailoring world: app cartamodelli parametrici (v1 consumer)
+
+> Piano implementativo derivato da `ANALISI-riscrittura-seamly2d-typescript.md` (§5 scope, §6
+> architettura pattern-as-data). Stato: DRAFT in review.
+
+## 1. Contesto e obiettivo
+
+gorlium-bento è un monorepo pnpm con una SPA Vite+React (`@gorlium/app`, hub multi-mondo a `/`,
+mondi annidati tipo `/terrariums`) e un design system condiviso (`@gorlium/design-system`),
+deploy su Netlify. Il mondo **Tailoring** (oggi disabilitato nel hub) diventa un'app consumer:
+
+- L'utente inserisce le **proprie misure** in un form (un solo set per utente, modificabile,
+  persistito in localStorage).
+- Sceglie un **cartamodello parametrico** da un catalogo authored dal maintainer **in codice
+  come dati** (op-list JSON tipizzate, NON funzioni draft libere — vincolo architetturale §6.5
+  per compatibilità col futuro CAD v2).
+- Vede l'**anteprima SVG** del cartamodello calcolato sulle sue misure, con **layer opzionali
+  toggleabili** (margini di cucitura, tacche, grainline/linee interne, etichette).
+- Scarica il **PDF tiled** (A4/Letter multi-pagina con crocini di allineamento) per stampa
+  casalinga a scala fisica esatta.
+
+Non-goals v1: CAD di costruzione, multisize/grading, database misure, nesting ottimizzato,
+DXF/EPS, import .val, i18n, account/backend, anteprima live durante l'editing misure.
+
+## 2. Architettura
+
+```
+packages/
+  pattern-engine/     @gorlium/pattern-engine — op-set + interprete su @freesewing/core. Puro TS, zero DOM.
+  patterns/           @gorlium/patterns — catalogo: op-list tipizzate + metadati (misure richieste, opzioni, immagini)
+apps/ (o struttura attuale)
+  app/                @gorlium/app — nuova route lazy /tailoring: form misure, catalogo, anteprima, export
+```
+
+Scelte tecniche (decise):
+- Motore: **@freesewing/core** (MIT, puro ESM; verificato: draft ~1ms, browser-ready).
+- Op-set proprio JSON/TS + **interprete = un design FreeSewing generico** la cui draft() esegue
+  le op chiamando i primitivi core (Point.shift, Path.offset, intersezioni, splitCurve…).
+- Rendering: **SVG via React** da `asRenderProps()`; layer = `<g>` condizionali.
+- PDF: **pdf-lib** client-side, dimensioni fisiche esatte + crocini.
+- Stato: **Zustand + persist** (localStorage) per misure e preferenze layer.
+- Validazione: **Zod** — schema misure per pattern, validazione form.
+- Test: **Vitest**, golden test sul motore (op-list + misure fisse → snapshot coordinate/SVG).
+
+## 3. Fasi
+
+### Fase 0 — Scaffolding (S)
+- [ ] Package `@gorlium/pattern-engine` e `@gorlium/patterns` nel monorepo (tsconfig base
+      condiviso, tsgo, verbatimModuleSyntax come il resto del repo).
+- [ ] Dipendenza `@freesewing/core` (+ `@freesewing/plugin-annotations` se usato per tacche/
+      grainline/title) vendorizzata o pinned.
+- [ ] **Pipeline test da creare** (oggi non esiste: root `package.json` ha solo
+      `start/build/typecheck` e `turbo.json` non ha un task `test`): aggiungere Vitest ai nuovi
+      package, task `test` in `turbo.json` (`dependsOn: ["^build"]` non necessario, no cache
+      su watch), script root `"test": "turbo run test"`.
+
+### Fase 1 — Op-set e interprete (M)
+- [ ] Definire i tipi dell'op-set v1 (subset minimo sufficiente per i primi 2 pattern del
+      catalogo): `point.base`, `point.atDistanceAngle`, `point.alongLine`, `point.intersectLines`,
+      `point.onCurve`, `curve.spline`, `curve.arc`, `path.build`, `piece.define` (contorno,
+      margine on/off e larghezza, tacche su nodi, grainline, label anchor), `mirror`, `rotate`.
+- [ ] Interprete: design FreeSewing generico che esegue una op-list; risoluzione referenze per
+      id; errori chiari (op malformata, referenza mancante, misura mancante).
+- [ ] Espressioni numeriche v1: **niente parser di formule custom** — le op usano funzioni TS
+      tipizzate `(m: Measurements) => number` oppure valori literal. (Parser user-facing
+      rimandato al CAD v2; le op-list restano serializzabili perché le espressioni-funzione
+      vivono nel catalogo TS, non in JSON runtime.)
+- [ ] Golden test: op-list di riferimento + misure fisse → coordinate attese.
+
+### Fase 2 — Primo pattern del catalogo (M)
+- [ ] Scegliere e scrivere come op-list il pattern pilota (candidato: gonna dritta o canotta —
+      pochi pezzi, poche misure).
+- [ ] Metadati: misure richieste (con range validi per Zod), opzioni (es. lunghezza), immagini.
+- [ ] Verifica manuale a scala reale (stampa e misura con metro).
+
+### Fase 3 — UI: form misure + catalogo + anteprima (M/L)
+- [ ] **Route tree** `/tailoring` in `App.tsx` sul modello di `/terrariums`: `TailoringLayout`
+      (lazy) con figli `index` (catalogo), `:patternId` (pagina pattern), `measurements`
+      (form misure). Riattivare il mondo in `Hub.tsx`.
+- [ ] **Background pre-mount**: lo script in `packages/app/index.html` colora light solo `/` e
+      dark tutto il resto — decidere il colore del mondo Tailoring e aggiornare lo script
+      (es. mappa path→colore), per evitare il flash col tema dei terrari.
+- [ ] **Estensione design-system** (necessaria: `TextField` è solo string senza error state,
+      `Form` ha solo un banner d'errore top-level): aggiungere a `@gorlium/design-system` un
+      `NumberField` (o `TextField` con `type`/`error`/`helperText`) e supporto errori
+      per-campo, riusando lo styling `g-field`/`g-input` esistente.
+- [ ] Form misure con Zod (unità cm; conversioni rimandate), persist Zustand, errori per-campo
+      con range dai metadati del pattern.
+- [ ] Pagina catalogo (griglia dai metadati) e pagina pattern.
+- [ ] Anteprima SVG con toggle layer: cucitura/taglio (margini), tacche, grainline+interni,
+      etichette. Zoom/pan basilare (viewBox).
+- [ ] Stati vuoti/errore: misure mancanti per il pattern → CTA al form.
+
+### Fase 4 — Export PDF tiled (M)
+- [ ] Impaginazione semplice: bounding box dei pezzi → distribuzione su pagine senza
+      sovrapposizioni (griglia per pezzo, nessun nesting).
+- [ ] Generazione pdf-lib: pagine A4/Letter, margini stampante, crocini + coordinate di
+      incollaggio (es. colonna/riga), quadrato di calibrazione 10×10cm sulla prima pagina.
+- [ ] Test di stampa fisica: quadrato di calibrazione misurato a mano.
+
+### Fase 5 — Rifiniture e release (S)
+- [ ] Empty state del mondo Tailoring nel hub. **Head/meta**: oggi esiste solo il `<title>`
+      statico in `index.html` e nessuna gestione head per route né analytics — aggiornare il
+      title via `document.title` on-route (accettando il limite SPA per gli OG: i crawler
+      vedranno i meta statici; prerender/SSR fuori scope v1).
+- [ ] Secondo pattern nel catalogo per validare che l'op-set generalizzi.
+- [ ] Aggiornare ANALISI/memorie; changelog.
+
+Stime: S ≤ 0,5 g; M = 1–3 g; L = 3–5 g. Totale v1 ≈ 2–3 settimane part-time.
+
+## 4. Rischi e mitigazioni
+
+| Rischio | Mitigazione |
+|---|---|
+| L'op-set v1 troppo povero per pattern reali | Progettarlo estraendolo dal pattern pilota reale, non in astratto; §6.2 mappa già i primitivi necessari |
+| Scala fisica del PDF sbagliata (unità FS = mm; PDF = punti) | Quadrato di calibrazione + golden test sulle conversioni mm→pt |
+| Path.offset di FreeSewing insufficiente per margini con angoli difficili | Accettare in v1 (pattern semplici); fallback Clipper2 documentato in analisi §5 |
+| Lock-in su funzioni-espressione TS non serializzabili in JSON puro | Confinare le espressioni in un modulo per pattern; il CAD v2 introdurrà il parser e migrerà |
+| Il mondo hub SPA cresce di bundle | Route lazy + code splitting; engine e pdf-lib caricati on demand |
+
+## 5. Criteri di accettazione v1
+
+1. Un utente senza istruzioni inserisce le misure, apre il pattern pilota, toggla i layer,
+   scarica il PDF, lo stampa: il quadrato di calibrazione misura 10,0 cm ± 1 mm.
+2. Le misure persistono al reload e si riapplicano a ogni pattern del catalogo.
+3. Golden test verdi sul motore; typecheck tsgo pulito; nessuna regressione nel resto del hub.
+4. Le op-list del catalogo non contengono codice di rendering né riferimenti a React.

--- a/PLAN-ts7-readability.md
+++ b/PLAN-ts7-readability.md
@@ -1,0 +1,94 @@
+# Piano: migrazione TypeScript 7 (tsgo) + leggibilità del repo
+
+Repo: `gorlium-bento` (pnpm monorepo: `packages/app` Vite+React, `packages/design-system` tsup).
+Obiettivo: rendere il repo pronto per TypeScript 7 (compiler nativo, oggi `@typescript/native-preview` / `tsgo`)
+e più leggibile/manutenibile, applicando KISS, DRY e i principi SOLID **senza over-engineering**
+(è un sito personale di ~1000 righe: la semplicità È la best practice).
+
+Evidenze già raccolte empiricamente (tsgo 7.0.0-dev eseguito sul repo):
+- `packages/app`: tsgo passa pulito (exit 0).
+- `packages/design-system`: 2 errori `TS2882` sugli import CSS side-effect (`./tokens/tokens.css`, `./styles.css`) — tsc 5.7 li accetta, TS7 no.
+- Con `verbatimModuleSyntax` + `isolatedModules`: ~31 errori app + ~15 DS, tutti `TS1484` meccanici (import type), autofissabili.
+- `src/i18next.d.ts` importa `./i18n/i18n` che NON esiste (il file vero è `packages/app/i18n.ts`): l'augmentation `CustomTypeOptions` è dead code, silenziata da `skipLibCheck`. Conseguenza reale: `t()` mai tipizzato → è il buco che ha lasciato passare il crash prod della pagina how-to (string vs string[] in en.json).
+- `packages/app/tsconfig.app.json` è orfano e rotto (include `packages/app/src` relativo a `packages/app` → path inesistente); nessuno lo referenzia.
+- `tsconfig.tsbuildinfo` è committato (artefatto di build).
+- `Lore.tsx` non è più importato da nessuno (pagina morta dopo la ristrutturazione hub); chiave i18n `header.blog` inutilizzata.
+- Typo CSS: `margintop: 1vh` in `packages/app/src/pages/Instructions.module.css:48` (warning a ogni build).
+- Il design-system non viene MAI typecheckato: `build` = tsup (esbuild, no typecheck), l'unico check è indiretto via l'app.
+- tsup `--dts` usa l'API JS di `typescript` 5.x: il compiler nativo non la espone → il DS deve tenere TS 5 come devDep finché tsup non supporta il nativo.
+
+---
+
+## PR 1 — Preparazione TS7 (rischio zero, nessun cambio di comportamento)
+
+1. **`packages/design-system/src/css.d.ts`** con `declare module "*.css";` → risolve i 2 errori TS2882 sotto tsgo. (L'app non ne ha bisogno: `vite/client` già dichiara `*.css`.)
+2. **Elimina `packages/app/tsconfig.app.json`** (orfano, include rotto).
+3. **Untrack `packages/app/tsconfig.tsbuildinfo`** e aggiungilo a `.gitignore`.
+4. **Fix typo `margintop` → `margin-top`** in `Instructions.module.css` (attenzione: la regola ha già un `margin-top: 4vh` tre righe sotto — verificare visivamente quale dei due è l'intento e tenere UNO solo dei due valori).
+5. **Script `typecheck`** in entrambi i package (`tsc --noEmit` / `tsc -p tsconfig.json --noEmit`) + **nuovo task `typecheck` in `turbo.json`** (oggi non esiste: turbo ha solo `build` e `start`) → il DS diventa finalmente typecheckabile; da oggi ogni regressione di tipo nel DS si vede subito. In PR 1 gli script usano `tsc`; lo switch a `tsgo` avviene in PR 4.
+
+Verifica: `pnpm build` verde; nessun diff visivo; check TS7 **ad-hoc** con `pnpm dlx @typescript/native-preview -p <pkg>/tsconfig.json` = 0 errori su entrambi i package (il binario `tsgo` NON è ancora una dipendenza del repo in PR 1 — lo diventa, alla root, solo in PR 4; fino ad allora la verifica nativa passa da `pnpm dlx`).
+
+## PR 2 — Riattivare la tipizzazione i18n + pulizia dead code (prevenzione bug)
+
+Stato verificato empiricamente (import fixato in prova su una working copy, poi ripristinato): con il solo fix dell'import le chiavi inesistenti diventano errori ✅, MA le chiavi con valore array (`instructions.*.content`, `dev.dev1.content`, ecc.) risultano **rotte nel tipo** — escluse dall'unione delle chiavi valide o con ritorno `unknown` — perché `MapLeafNodes` in `i18n.ts` non preserva fedelmente gli array; emergono ~15 errori reali in `Dev.tsx` e `Instructions.tsx`. Quindi il fix dell'import da solo NON garantisce la protezione compile-time sulla classe di bug string-vs-string[]: serve anche il punto 2.
+
+1. **Fix import in `src/i18next.d.ts`**: `./i18n/i18n` → `../i18n`. Riattiva `CustomTypeOptions`.
+2. **Eliminare `MapLeafNodes` e le cast in `i18n.ts`** (KISS + fix degli array): quella macchineria esisteva solo per il `LocalizedString` brandizzato di Bento, che oggi è `type LocalizedString = string` — è dead weight che per giunta rompe la tipizzazione degli array. Usare direttamente `export const resources = { en: enMessages } as const` (tipo = `typeof enMessages`): gli array tornano `string[]` fedeli. Poi correggere i call-site emersi (nei punti dove si consuma un array serve `t(key, { returnObjects: true })` per avere il tipo corretto, o tipizzazione esplicita del consumo in `PostSection.text` / `Instructions.content`).
+   **Criterio di accettazione (entrambi obbligatori)**: (a) una chiave inventata `t("bogus.x")` deve fallire il typecheck; (b) `t("instructions.step1.content")` deve tipare `string[]` al call-site — non `unknown`, non `string`.
+3. **Dead code i18n / lingua**:
+   - Il sito è English-only (`lng: "en"`, switch disabilitato): rimuovere `it.json`, il blocco commentato dello switch lingua in `App`/layout, `handleLanguageChange`, e la chiave `header.blog` inutilizzata.
+   - **Stato persistito**: rimuovere anche l'`useEffect` in `App.tsx` (righe ~76-80) che ripristina `localStorage["language"]` — altrimenti i browser che hanno `language=it` salvato richiamerebbero `i18n.changeLanguage("it")` su risorse italiane ormai rimosse. Attenzione: l'inizializzazione i18n avviene SOLO tramite l'import side-effect di `../i18n` in `App.tsx` → spostare quell'import in `main.tsx` (posto naturale per un side-effect di bootstrap) quando si elimina l'effect, così la rimozione non spegne i18n. La chiave stantia in localStorage può restare (innocua senza codice che la legge); niente migrazione.
+   - `debug: true` in `i18n.ts` → `debug: import.meta.env.DEV` (oggi logga in produzione).
+   - SOLID/ISP: `Header` dichiara `onToggleLanguage` e `initialLanguage` nelle props ma non li usa (il componente destruttura solo `list`; `LanguageSwitch` è solo codice commentato) → rimuovere le props morte dall'interfaccia e il commento.
+4. **DECISIONE UTENTE — `Lore.tsx`**: pagina non raggiungibile (nessuna route). Opzioni: (a) eliminarla insieme alle chiavi `lore.*` (recuperabile da git), (b) rimontarla su una route (es. `/terrariums/lore`). Il piano assume (a) salvo indicazione contraria — il contenuto resta nella history.
+
+Verifica: typecheck verde su entrambi i package; smoke test di tutte le route; i due criteri di accettazione del punto 2 verificati (chiave inventata → errore; chiave-array → `string[]`). Con questo, il caso "en.json content string vs array" fallisce a compile time.
+
+## PR 3 — Leggibilità / SRP / DRY (zero cambi di comportamento)
+
+1. **`App.tsx` = solo routing (SRP)**: estrarre `TerrariumLayout` in `src/layouts/TerrariumLayout.tsx`.
+2. **Rinomina `Homepage.tsx` → `TerrariumHome.tsx`**: il nome attuale mente (è la home dell'area terrari montata su `/terrariums`, non la homepage del sito — quella è `Hub`).
+3. **Riordinare `Hub.tsx` senza spacchettarlo** (243 righe, il file più grande — ma è una leaf page con dati colocati e un hook page-local: creare `content/`, `hooks/` e 4 componenti nuovi per un sito personale sarebbe proprio la violazione di KISS che questo piano vieta):
+   - restare su UN file; dentro il file, estrarre il ternario gigante mobile/desktop in due sotto-componenti locali (`HubMobileList`, `HubDesktopList`) definiti nello stesso modulo;
+   - costanti di stile ripetute con nomi in cima al file; `WORLDS`, `useIsMobile` e `RESTRICTED_BADGE` restano dove sono;
+   - estrarre in file separati SOLO se/quando un secondo consumatore reale apparirà (es. `useIsMobile` servisse a un'altra pagina).
+4. **DRY: `preloadImage`** duplicata identica in `Homepage.tsx` e `Terrariums.tsx` → `src/lib/preloadImage.ts`.
+5. **`Instructions.tsx`: numerazione onesta.** Oggi i numeri sono hardcoded e le chiavi mentono (contenuto di `step3` renderizzato come "1.", `step2` come "2.", `step1` come "3."). Fix: array ordinato `steps` e numerazione derivata dall'indice; rinominare le chiavi i18n secondo l'ordine reale (`maintenance`, `condensation`, `placement`). Mai più numeri magici disallineati dai contenuti.
+6. **`Header` (DS) — correttezza e disaccoppiamento**:
+   - doppia navigazione: la cella fa `onClick={() => window.location.href = link}` E contiene `<a href>`. Il fix NON è tenere solo l'`<a>` interno così com'è (hit-area a tutta cella e hover-fill vivono su `.g-header__cell`: si perderebbero entrambi) ma **rendere l'`<a>` stesso la cella**: `<a className="g-header__cell g-header__link" href>` unico elemento, eliminando il `div` wrapper e il suo `onClick`. CSS in `styles.css`: `.g-header__cell` deve continuare a valere (ora sull'anchor: aggiungere `text-decoration: none` se serve, e adattare `.g-header__cell:hover .g-header__link` → `.g-header__cell:hover`). Risultato visivo/interattivo identico (tutta la cella cliccabile, hover-fill invariato), DOM più semplice e una sola navigazione;
+   - `list.slice(0, 5)` + `columns: 5` hardcoded → colonne = `list.length`, niente numero magico accoppiato all'app (DIP: il DS non deve sapere quante voci ha l'app);
+   - OPZIONALE (decisione): navigazione SPA. Oggi ogni voce fa full reload. Alternativa senza accoppiare il DS a react-router: prop `renderLink?: (href, label) => ReactNode`. KISS dice che il full reload è accettabile per questo sito → di default NON farlo, annotare solo la possibilità.
+7. **`vite.config.ts`**: verificare se il middleware `connect-history-api-fallback` è ridondante (Vite in dev ha già il fallback SPA con `appType: 'spa'` di default). Se i deep link funzionano senza, rimuovere middleware e dipendenza.
+
+Verifica: confronto screenshot prima/dopo su `/`, `/terrariums`, `/terrariums/gallery`, `/terrariums/how-to`, `/terrariums/contacts` (desktop + mobile); build e typecheck verdi.
+
+## PR 4 — Switch a TypeScript 7
+
+1. devDep **`@typescript/native-preview` alla ROOT del workspace** (una sola versione per tutto il monorepo; pnpm la rende disponibile come bin `tsgo` a entrambi i package — è da qui che arriva il binario usato dagli script del punto 2 e 3).
+2. App: `"build": "tsgo -b && vite build"` e `"typecheck": "tsgo -b"` (in alternativa più prudente: `"typecheck:native": "tsgo -b"` accanto a quello tsc e switch del build dopo un periodo di doppio binario).
+3. Design-system: lo script `typecheck` introdotto in PR 1 passa da `tsc --noEmit` a `tsgo -p tsconfig.json --noEmit`. Il pacchetto **resta** anche su `typescript` 5.x come devDep, usato SOLO da `tsup --dts` (l'API JS del compiler che il nativo non espone) — commento nel package.json che spiega il perché.
+4. Quando TS7 stable uscirà come `typescript@7`: sostituire il preview alla root con la major e rimuovere il doppio binario.
+
+Verifica: deploy-preview Netlify verde (la build Netlify esegue lo script `build` → deve funzionare col binario nativo su Linux); `tsgo -b` exit 0 in locale.
+
+## PR 5 (opzionale) — Strictness moderna
+
+1. `verbatimModuleSyntax: true` + `isolatedModules: true` nei due tsconfig (allinea il typecheck alla realtà transpile-per-file di esbuild/Vite/tsup).
+2. Autofix dei ~46 `TS1484` misurati con ESLint `@typescript-eslint/consistent-type-imports` + `--fix`; aggiungere la regola alla config ESLint per non regredire.
+3. DRY config: `tsconfig.base.json` alla root con le `compilerOptions` comuni (oggi duplicate quasi identiche nei due package), i package fanno `extends`.
+
+Verifica: tsgo verde con i nuovi flag su entrambi i package.
+
+---
+
+## Non-goals (KISS applicato al piano stesso)
+
+- Nessuna nuova libreria UI/CSS/state-management.
+- Nessuna introduzione di test framework in queste PR (eventuale follow-up separato: un paio di smoke test Playwright sulle route varrebbero più di unit test qui).
+- Nessuna riscrittura del design system o astrazione "a prova di futuro" non richiesta dai problemi elencati.
+- Nessun cambio visivo o di comportamento fuori da quelli esplicitati (fix typo CSS e doppia navigazione Header).
+
+## Ordine e dipendenze
+
+PR 1 → PR 2 → PR 3 → PR 4 → (PR 5). PR 1 e 2 sono piccole e indipendenti dal refactor; PR 4 va dopo PR 1 (senza `css.d.ts` tsgo fallisce sul DS). PR 3 può procedere in parallelo a PR 4 ma va mergiata prima dello switch per non typecheckare due volte il churn.

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -7,3 +7,9 @@
 
 VITE_TELEGRAM_BOT_TOKEN=123456789:your-bot-token-here
 VITE_TELEGRAM_CHAT_ID=your-chat-id-here
+
+# Baltici (trip expenses) — InstantDB app ID. Public client-side identifier.
+# Create an app at https://www.instantdb.com (dashboard), then set open permissions
+# (view/create/update = "true", delete = "false"). Without this, the Baltici area
+# shows a "not configured" screen; the rest of the site is unaffected.
+VITE_INSTANT_APP_ID=your-instantdb-app-id-here

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,10 +7,12 @@
     "build": "tsgo -b && vite build",
     "typecheck": "tsgo -b",
     "lint": "eslint .",
-    "start": "vite"
+    "start": "vite",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gorlium/design-system": "workspace:*",
+    "@instantdb/react": "^1.0.49",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
     "i18next": "^24.2.2",
@@ -32,6 +34,7 @@
     "sass-embedded": "^1.83.1",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.19.0",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -6,6 +6,12 @@ import Terrariums from "./pages/Terrariums";
 import Dev from "./pages/Dev";
 import Contacts from "./pages/Contacts";
 import { Instructions } from "./pages/Instructions";
+import BalticiLayout from "./layouts/BalticiLayout";
+import BalticiHome from "./pages/baltici/BalticiHome";
+import BalticiExpenses from "./pages/baltici/BalticiExpenses";
+import BalticiAddExpense from "./pages/baltici/BalticiAddExpense";
+import BalticiSettleUp from "./pages/baltici/BalticiSettleUp";
+import BalticiPeople from "./pages/baltici/BalticiPeople";
 
 function App() {
   return (
@@ -18,6 +24,14 @@ function App() {
           <Route path="how-to" element={<Instructions />} />
           <Route path="contacts" element={<Contacts />} />
           <Route path="dev" element={<Dev />} />
+        </Route>
+        <Route path="/baltici" element={<BalticiLayout />}>
+          <Route index element={<BalticiHome />} />
+          <Route path="expenses" element={<BalticiExpenses />} />
+          <Route path="expenses/new" element={<BalticiAddExpense />} />
+          <Route path="expenses/:id/edit" element={<BalticiAddExpense />} />
+          <Route path="who-owes" element={<BalticiSettleUp />} />
+          <Route path="people" element={<BalticiPeople />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/packages/app/src/baltici/calc.test.ts
+++ b/packages/app/src/baltici/calc.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { shareOf, balances, totals, simplifyDebts } from "./calc";
+import type { EqualExpense, ExactExpense, GroupState, Person } from "./model";
+import { parseAmountToCents, formatCents } from "./money";
+import { validateExpense } from "./validation";
+
+function person(id: string, i: number): Person {
+  return { id, name: id, color: "#000", createdAt: i };
+}
+
+const A = person("a", 0);
+const B = person("b", 1);
+const C = person("c", 2);
+const PEOPLE = [A, B, C];
+
+function equal(over: string[], amount: number, payer = "a"): EqualExpense {
+  return {
+    id: "e",
+    description: "x",
+    amountCents: amount,
+    payerId: payer,
+    date: "2026-07-19",
+    createdAt: 0,
+    splitMode: "equal",
+    participants: over,
+  };
+}
+
+describe("shareOf — equal split", () => {
+  it("splits evenly when divisible", () => {
+    expect(shareOf(equal(["a", "b", "c"], 900), PEOPLE)).toEqual({ a: 300, b: 300, c: 300 });
+  });
+
+  it("distributes the remainder by canonical people order; sum === amount", () => {
+    const shares = shareOf(equal(["a", "b", "c"], 1000), PEOPLE); // 1000/3
+    expect(shares).toEqual({ a: 334, b: 333, c: 333 });
+    expect(shares.a + shares.b + shares.c).toBe(1000);
+  });
+
+  it("is independent of participants[] ordering (deterministic rounding)", () => {
+    const s1 = shareOf(equal(["a", "b", "c"], 1000), PEOPLE);
+    const s2 = shareOf(equal(["c", "a", "b"], 1000), PEOPLE);
+    const s3 = shareOf(equal(["b", "c", "a"], 1000), PEOPLE);
+    expect(s2).toEqual(s1);
+    expect(s3).toEqual(s1);
+  });
+
+  it("supports a subset (payer excluded from participants)", () => {
+    const shares = shareOf(equal(["b", "c"], 1000, "a"), PEOPLE);
+    expect(shares).toEqual({ b: 500, c: 500 });
+    expect(shares.a).toBeUndefined();
+  });
+
+  it("throws on zero participants instead of dividing by zero", () => {
+    expect(() => shareOf(equal([], 1000), PEOPLE)).toThrow();
+  });
+});
+
+describe("shareOf — exact split", () => {
+  it("returns exactShares as-is", () => {
+    const e: ExactExpense = {
+      id: "e",
+      description: "x",
+      amountCents: 1000,
+      payerId: "a",
+      date: "2026-07-19",
+      createdAt: 0,
+      splitMode: "exact",
+      exactShares: { a: 700, b: 300 },
+    };
+    expect(shareOf(e, PEOPLE)).toEqual({ a: 700, b: 300 });
+  });
+});
+
+describe("balances", () => {
+  it("the user example: pay 120€, split among all — payer +105, others −15", () => {
+    const people = Array.from({ length: 8 }, (_, i) => person(String(i), i));
+    const state: GroupState = {
+      name: "trip",
+      people,
+      expenses: [
+        {
+          id: "e",
+          description: "dinner",
+          amountCents: 12000,
+          payerId: "0",
+          date: "2026-07-19",
+          createdAt: 0,
+          splitMode: "equal",
+          participants: people.map((p) => p.id),
+        },
+      ],
+    };
+    const net = balances(state);
+    expect(net["0"]).toBe(12000 - 1500);
+    for (let i = 1; i < 8; i++) expect(net[String(i)]).toBe(-1500);
+  });
+
+  it("sum of balances is always 0 (random-ish scenarios)", () => {
+    const people = Array.from({ length: 6 }, (_, i) => person(String(i), i));
+    const amounts = [1000, 333, 7777, 12, 9999, 501, 88, 4200];
+    const expenses = amounts.map((amt, k): EqualExpense => {
+      const size = (k % 5) + 1;
+      const participants = people.slice(0, size).map((p) => p.id);
+      return {
+        id: "e" + k,
+        description: "x",
+        amountCents: amt,
+        payerId: String(k % 6),
+        date: "2026-07-19",
+        createdAt: k,
+        splitMode: "equal",
+        participants,
+      };
+    });
+    const net = balances({ name: "t", people, expenses });
+    const sum = Object.values(net).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(0);
+  });
+});
+
+describe("totals", () => {
+  it("sums paid per payer and the grand total", () => {
+    const state: GroupState = {
+      name: "t",
+      people: PEOPLE,
+      expenses: [equal(["a", "b", "c"], 900, "a"), equal(["a", "b"], 200, "b")],
+    };
+    const { perPerson, grand } = totals(state);
+    expect(perPerson.a).toBe(900);
+    expect(perPerson.b).toBe(200);
+    expect(perPerson.c).toBe(0);
+    expect(grand).toBe(1100);
+  });
+});
+
+describe("simplifyDebts", () => {
+  it("zeroes out every balance and produces no negative payments", () => {
+    const net = { a: 1500, b: -1000, c: -500 };
+    const settlements = simplifyDebts(net);
+    for (const s of settlements) expect(s.amountCents).toBeGreaterThan(0);
+
+    const applied: Record<string, number> = { ...net };
+    for (const s of settlements) {
+      applied[s.fromId] += s.amountCents;
+      applied[s.toId] -= s.amountCents;
+    }
+    for (const v of Object.values(applied)) expect(v).toBe(0);
+  });
+
+  it("no settlements when everything is settled", () => {
+    expect(simplifyDebts({ a: 0, b: 0 })).toEqual([]);
+  });
+});
+
+describe("parseAmountToCents", () => {
+  it("accepts comma and dot", () => {
+    expect(parseAmountToCents("12,50")).toEqual({ cents: 1250 });
+    expect(parseAmountToCents("12.50")).toEqual({ cents: 1250 });
+    expect(parseAmountToCents(" 7 ")).toEqual({ cents: 700 });
+  });
+  it("rejects empty, non-numeric, negative, zero and >2 decimals", () => {
+    expect(parseAmountToCents("")).toEqual({ error: "empty" });
+    expect(parseAmountToCents("abc")).toEqual({ error: "invalid" });
+    expect(parseAmountToCents("-5")).toEqual({ error: "invalid" });
+    expect(parseAmountToCents("0")).toEqual({ error: "nonpositive" });
+    expect(parseAmountToCents("1,234")).toEqual({ error: "invalid" });
+  });
+  it("round-trips through formatCents", () => {
+    expect(formatCents(1250)).toBe("12,50");
+  });
+});
+
+describe("validateExpense", () => {
+  const ids = new Set(["a", "b", "c"]);
+
+  it("accepts a valid equal draft", () => {
+    expect(
+      validateExpense(
+        { splitMode: "equal", description: "d", amountCents: 900, payerId: "a", date: "2026-07-19", participants: ["a", "b", "c"] },
+        ids
+      )
+    ).toBeNull();
+  });
+
+  it("rejects equal with no participants", () => {
+    expect(
+      validateExpense(
+        { splitMode: "equal", description: "d", amountCents: 900, payerId: "a", date: "2026-07-19", participants: [] },
+        ids
+      )
+    ).toBe("no-participants");
+  });
+
+  it("rejects exact shares that do not sum to the total", () => {
+    expect(
+      validateExpense(
+        { splitMode: "exact", description: "d", amountCents: 1000, payerId: "a", date: "2026-07-19", exactShares: { a: 600, b: 300 } },
+        ids
+      )
+    ).toBe("shares-mismatch");
+  });
+
+  it("rejects bad amount and unknown payer", () => {
+    expect(
+      validateExpense(
+        { splitMode: "equal", description: "d", amountCents: 0, payerId: "a", date: "2026-07-19", participants: ["a"] },
+        ids
+      )
+    ).toBe("bad-amount");
+    expect(
+      validateExpense(
+        { splitMode: "equal", description: "d", amountCents: 100, payerId: "z", date: "2026-07-19", participants: ["a"] },
+        ids
+      )
+    ).toBe("bad-payer");
+  });
+});

--- a/packages/app/src/baltici/calc.ts
+++ b/packages/app/src/baltici/calc.ts
@@ -1,0 +1,137 @@
+// Baltici — pure calculation engine. No React, no storage. Integer cents only.
+//
+// Invariants (covered by calc.test.ts):
+//   - for every expense, sum(shareOf) === amountCents (no cent created/lost)
+//   - sum(balances) === 0
+//   - simplifyDebts fully zeroes every balance, no negative payments
+//   - rounding is deterministic and independent of participants[] ordering
+
+import {
+  type Expense,
+  type GroupState,
+  type Person,
+  type PersonId,
+} from "./model";
+
+function orderIndex(people: Person[]): Map<PersonId, number> {
+  const m = new Map<PersonId, number>();
+  people.forEach((p, i) => m.set(p.id, i));
+  return m;
+}
+
+/**
+ * Amount owed by each participant of a single expense, in integer cents.
+ * equal: split evenly; the remainder (0..n-1 cents) is handed out one cent each
+ * following the canonical order of `people` (NOT the order of participants[],
+ * which depends on toggle order) → same logical subset ⇒ same assignment.
+ * exact: returns exactShares as-is.
+ */
+export function shareOf(
+  expense: Expense,
+  people: Person[]
+): Record<PersonId, number> {
+  if (expense.splitMode === "exact") {
+    return { ...expense.exactShares };
+  }
+
+  const parts = expense.participants;
+  if (parts.length === 0) {
+    // Illegal state (validation prevents saving it); fail fast, never /0.
+    throw new Error("equal expense with no participants");
+  }
+
+  const order = orderIndex(people);
+  const sorted = [...parts].sort(
+    (a, b) =>
+      (order.get(a) ?? Number.MAX_SAFE_INTEGER) -
+      (order.get(b) ?? Number.MAX_SAFE_INTEGER)
+  );
+
+  const n = sorted.length;
+  const base = Math.floor(expense.amountCents / n);
+  const remainder = expense.amountCents - base * n; // 0..n-1
+
+  const out: Record<PersonId, number> = {};
+  sorted.forEach((pid, idx) => {
+    out[pid] = base + (idx < remainder ? 1 : 0);
+  });
+  return out;
+}
+
+/**
+ * Net balance per person over all expenses, in cents.
+ * net = sum(paid as payer) − sum(owed shares).
+ * > 0 → in credit (the group owes them), < 0 → in debt.
+ */
+export function balances(state: GroupState): Record<PersonId, number> {
+  const net: Record<PersonId, number> = {};
+  for (const p of state.people) net[p.id] = 0;
+
+  for (const e of state.expenses) {
+    net[e.payerId] = (net[e.payerId] ?? 0) + e.amountCents;
+    const shares = shareOf(e, state.people);
+    for (const [pid, share] of Object.entries(shares)) {
+      net[pid] = (net[pid] ?? 0) - share;
+    }
+  }
+  return net;
+}
+
+/** Total paid (as payer) per person + grand total of the trip, in cents. */
+export function totals(state: GroupState): {
+  perPerson: Record<PersonId, number>;
+  grand: number;
+} {
+  const perPerson: Record<PersonId, number> = {};
+  for (const p of state.people) perPerson[p.id] = 0;
+
+  let grand = 0;
+  for (const e of state.expenses) {
+    perPerson[e.payerId] = (perPerson[e.payerId] ?? 0) + e.amountCents;
+    grand += e.amountCents;
+  }
+  return { perPerson, grand };
+}
+
+export interface Settlement {
+  fromId: PersonId;
+  toId: PersonId;
+  amountCents: number;
+}
+
+/**
+ * Minimal-ish set of payments that zero out the net balances (greedy
+ * two-pointer: largest debtor pays largest creditor). Deterministic thanks to
+ * a stable sort by amount then id.
+ */
+export function simplifyDebts(net: Record<PersonId, number>): Settlement[] {
+  const creditors: { id: PersonId; amt: number }[] = [];
+  const debtors: { id: PersonId; amt: number }[] = [];
+
+  for (const [id, amt] of Object.entries(net)) {
+    if (amt > 0) creditors.push({ id, amt });
+    else if (amt < 0) debtors.push({ id, amt: -amt });
+  }
+
+  const byAmountThenId = (
+    a: { id: PersonId; amt: number },
+    b: { id: PersonId; amt: number }
+  ) => b.amt - a.amt || (a.id < b.id ? -1 : 1);
+  creditors.sort(byAmountThenId);
+  debtors.sort(byAmountThenId);
+
+  const out: Settlement[] = [];
+  let ci = 0;
+  let di = 0;
+  while (ci < creditors.length && di < debtors.length) {
+    const c = creditors[ci];
+    const d = debtors[di];
+    const pay = Math.min(c.amt, d.amt);
+    if (pay > 0) out.push({ fromId: d.id, toId: c.id, amountCents: pay });
+    c.amt -= pay;
+    d.amt -= pay;
+    if (c.amt === 0) ci++;
+    if (d.amt === 0) di++;
+  }
+  return out;
+}

--- a/packages/app/src/baltici/colors.ts
+++ b/packages/app/src/baltici/colors.ts
@@ -1,0 +1,16 @@
+// Fixed palette for person avatars/colors (US-05). Cycles for any N.
+
+export const PERSON_COLORS = [
+  "#cc7a4f",
+  "#8faa57",
+  "#8aa0c8",
+  "#cda64e",
+  "#9b8cc4",
+  "#5fb3c6",
+  "#c65f8f",
+  "#6cae8f",
+];
+
+export function pickColor(index: number): string {
+  return PERSON_COLORS[((index % PERSON_COLORS.length) + PERSON_COLORS.length) % PERSON_COLORS.length];
+}

--- a/packages/app/src/baltici/components/ErrorBoundary.tsx
+++ b/packages/app/src/baltici/components/ErrorBoundary.tsx
@@ -1,0 +1,22 @@
+import { Component, type ReactNode } from "react";
+
+// Keeps a runtime failure inside the Baltici subtree (e.g. a data-layer error)
+// from blanking the rest of the gorlium site.
+export class ErrorBoundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("Baltici error boundary caught:", error);
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/packages/app/src/baltici/components/atoms.tsx
+++ b/packages/app/src/baltici/components/atoms.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties, ReactNode } from "react";
+import type { Person } from "../model";
+import { formatEuro } from "../money";
+
+const mono = "'Space Mono', monospace";
+
+export function PersonAvatar({ person, size = 30 }: { person: Person; size?: number }) {
+  const initial = person.name.trim().charAt(0).toUpperCase() || "?";
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        flex: "none",
+        borderRadius: "50%",
+        background: person.color,
+        color: "#fff",
+        font: `700 ${Math.round(size * 0.42)}px/1 ${mono}`,
+      }}
+    >
+      {initial}
+    </span>
+  );
+}
+
+/** Signed money: positive = credit (green), negative = debt (red), 0 = muted. */
+export function Money({ cents, bold = false }: { cents: number; bold?: boolean }) {
+  const color = cents > 0 ? "#3b7d3b" : cents < 0 ? "#a83232" : "inherit";
+  return (
+    <span style={{ font: `${bold ? 700 : 400} 14px/1 ${mono}`, color }}>
+      {formatEuro(cents)}
+    </span>
+  );
+}
+
+export function Row({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "12px 0",
+        borderTop: "1px solid currentColor",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        border: "1.5px dashed currentColor",
+        padding: 24,
+        textAlign: "center",
+        font: `400 14px/1.6 ${mono}`,
+        opacity: 0.8,
+        margin: "16px 0",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <h2 style={{ font: `700 13px/1 ${mono}`, letterSpacing: ".14em", textTransform: "uppercase", margin: "24px 0 4px" }}>
+      {children}
+    </h2>
+  );
+}

--- a/packages/app/src/baltici/components/formControls.tsx
+++ b/packages/app/src/baltici/components/formControls.tsx
@@ -1,0 +1,227 @@
+import type { Person, PersonId } from "../model";
+import { formatEuro } from "../money";
+
+const mono = "'Space Mono', monospace";
+
+const controlStyle = {
+  font: `400 14px/1 ${mono}`,
+  padding: "9px 10px",
+  border: "1.5px solid currentColor",
+  background: "transparent",
+  color: "inherit",
+  width: "100%",
+  boxSizing: "border-box" as const,
+};
+
+export function Label({ text }: { text: string }) {
+  return (
+    <span style={{ display: "block", font: `700 11px/1 ${mono}`, letterSpacing: ".1em", textTransform: "uppercase", marginBottom: 6, opacity: 0.75 }}>
+      {text}
+    </span>
+  );
+}
+
+export function TextInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <input
+      style={controlStyle}
+      value={value}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+export function AmountInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <input
+      style={controlStyle}
+      value={value}
+      inputMode="decimal"
+      placeholder="0,00"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+export function DateInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <input
+      type="date"
+      style={controlStyle}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+export function PersonSelect({
+  people,
+  value,
+  onChange,
+}: {
+  people: Person[];
+  value: PersonId | "";
+  onChange: (id: PersonId) => void;
+}) {
+  return (
+    <select
+      style={controlStyle}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="" disabled>
+        —
+      </option>
+      {people.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function SplitModeTabs({
+  value,
+  labels,
+  onChange,
+}: {
+  value: "all" | "subset" | "exact";
+  labels: { all: string; subset: string; exact: string };
+  onChange: (v: "all" | "subset" | "exact") => void;
+}) {
+  const items: { id: "all" | "subset" | "exact"; label: string }[] = [
+    { id: "all", label: labels.all },
+    { id: "subset", label: labels.subset },
+    { id: "exact", label: labels.exact },
+  ];
+  return (
+    <div style={{ display: "flex", gap: 6 }}>
+      {items.map((it) => {
+        const on = it.id === value;
+        return (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => onChange(it.id)}
+            style={{
+              flex: 1,
+              font: `${on ? 700 : 400} 12px/1 ${mono}`,
+              padding: "8px 4px",
+              border: "1.5px solid currentColor",
+              background: on ? "currentColor" : "transparent",
+              color: on ? "#ece7dd" : "inherit",
+              cursor: "pointer",
+            }}
+          >
+            {it.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ParticipantsToggle({
+  people,
+  selected,
+  onToggle,
+}: {
+  people: Person[];
+  selected: ReadonlySet<PersonId>;
+  onToggle: (id: PersonId) => void;
+}) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: 6 }}>
+      {people.map((p) => {
+        const on = selected.has(p.id);
+        return (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => onToggle(p.id)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              font: `${on ? 700 : 400} 13px/1 ${mono}`,
+              padding: "8px 10px",
+              border: "1.5px solid currentColor",
+              background: on ? "currentColor" : "transparent",
+              color: on ? "#ece7dd" : "inherit",
+              opacity: on ? 1 : 0.6,
+              cursor: "pointer",
+            }}
+          >
+            <span>{p.name}</span>
+            <span>{on ? "✓" : "○"}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ExactSharesEditor({
+  people,
+  values,
+  onChange,
+  remainderCents,
+}: {
+  people: Person[];
+  values: Record<PersonId, string>;
+  onChange: (id: PersonId, v: string) => void;
+  remainderCents: number;
+}) {
+  return (
+    <div>
+      <div style={{ display: "grid", gap: 6 }}>
+        {people.map((p) => (
+          <div key={p.id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ flex: 1, font: `400 13px/1 ${mono}` }}>{p.name}</span>
+            <input
+              style={{ ...controlStyle, width: 110 }}
+              inputMode="decimal"
+              placeholder="0,00"
+              value={values[p.id] ?? ""}
+              onChange={(e) => onChange(p.id, e.target.value)}
+            />
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          marginTop: 8,
+          font: `700 12px/1 ${mono}`,
+          color: remainderCents === 0 ? "#3b7d3b" : "#a83232",
+        }}
+      >
+        {remainderCents === 0
+          ? "OK"
+          : `${formatEuro(remainderCents)} da assegnare`}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/baltici/components/formControls.tsx
+++ b/packages/app/src/baltici/components/formControls.tsx
@@ -24,10 +24,12 @@ export function Label({ text }: { text: string }) {
 export function TextInput({
   value,
   onChange,
+  onBlur,
   placeholder,
 }: {
   value: string;
   onChange: (v: string) => void;
+  onBlur?: () => void;
   placeholder?: string;
 }) {
   return (
@@ -36,6 +38,7 @@ export function TextInput({
       value={value}
       placeholder={placeholder}
       onChange={(e) => onChange(e.target.value)}
+      onBlur={onBlur}
     />
   );
 }

--- a/packages/app/src/baltici/db.ts
+++ b/packages/app/src/baltici/db.ts
@@ -1,0 +1,58 @@
+// Baltici — InstantDB client (D1). Reactive, client-side, no login.
+//
+// The app ID is a PUBLIC client-side identifier → provided via a build-time env
+// var (same pattern as the Telegram contact form). When it's missing the app
+// still loads; the layout shows a "configure" screen instead of the pages, so
+// `db.useQuery` is never called without a real app ID.
+
+import { init, i } from "@instantdb/react";
+
+const APP_ID = import.meta.env.VITE_INSTANT_APP_ID;
+
+export const schema = i.schema({
+  entities: {
+    people: i.entity({
+      name: i.string(),
+      color: i.string(),
+      createdAt: i.number(), // persisted canonical order (rounding is order-sensitive)
+      deleted: i.boolean(), // soft-delete (permissions forbid hard delete)
+    }),
+    expenses: i.entity({
+      description: i.string(),
+      amountCents: i.number(),
+      payerId: i.string(),
+      date: i.string(),
+      splitMode: i.string(), // "equal" | "exact"
+      participants: i.json(), // PersonId[] (equal)
+      exactShares: i.json(), // Record<PersonId, number> (exact)
+      createdAt: i.number(),
+      deleted: i.boolean(), // soft-delete
+    }),
+    meta: i.entity({
+      groupName: i.string(),
+    }),
+  },
+});
+
+// init() throws synchronously on a missing/malformed app ID. Since this module is
+// imported at app startup (App → BalticiLayout → db), an uncaught throw here would
+// blank the WHOLE gorlium site, not just Baltici. So we init defensively: on any
+// failure `db` is null and the area shows its "not configured" screen — the rest of
+// the site keeps working. A correct app ID initializes normally.
+function createDb(): ReturnType<typeof init<typeof schema>> | null {
+  if (!APP_ID) return null;
+  try {
+    return init({ appId: APP_ID, schema });
+  } catch (err) {
+    console.error(
+      "Baltici: VITE_INSTANT_APP_ID is invalid — InstantDB not initialized.",
+      err
+    );
+    return null;
+  }
+}
+
+export const db = createDb();
+
+/** True when InstantDB is initialized with a valid app ID. */
+export const isConfigured = db !== null;

--- a/packages/app/src/baltici/model.ts
+++ b/packages/app/src/baltici/model.ts
@@ -1,0 +1,56 @@
+// Baltici — domain model (Splitwise light).
+//
+// A single group, no login, no "current user". All amounts are integer cents.
+// The Expense type is a discriminated union so there is exactly one source of
+// truth for "who shares an expense": `participants` for equal splits, the keys
+// of `exactShares` for exact splits.
+
+export type PersonId = string;
+export type ExpenseId = string;
+
+export interface Person {
+  id: PersonId;
+  name: string;
+  color: string;
+  createdAt: number; // persisted → canonical ordering (rounding is order-sensitive)
+}
+
+export type SplitMode = "equal" | "exact";
+
+interface ExpenseBase {
+  id: ExpenseId;
+  description: string;
+  amountCents: number; // total, integer cents, > 0
+  payerId: PersonId; // chosen explicitly (no "current user")
+  date: string; // "YYYY-MM-DD"
+  createdAt: number;
+}
+
+export interface EqualExpense extends ExpenseBase {
+  splitMode: "equal";
+  participants: PersonId[]; // ≥ 1, unique; order not significant (canonicalized in calc)
+}
+
+export interface ExactExpense extends ExpenseBase {
+  splitMode: "exact";
+  exactShares: Record<PersonId, number>; // cents per person, sums to amountCents
+}
+
+export type Expense = EqualExpense | ExactExpense;
+
+export interface GroupState {
+  name: string;
+  people: Person[]; // canonical order (by createdAt) — see calc.shareOf
+  expenses: Expense[];
+}
+
+/** The people who share an expense — the single source of truth per split mode. */
+export function participantsOf(e: Expense): PersonId[] {
+  return e.splitMode === "equal" ? e.participants : Object.keys(e.exactShares);
+}
+
+/** Every person referenced by an expense: payer + participants. Used to block
+ *  removing a person who is still involved somewhere. */
+export function personIdsInExpense(e: Expense): PersonId[] {
+  return Array.from(new Set<PersonId>([e.payerId, ...participantsOf(e)]));
+}

--- a/packages/app/src/baltici/money.ts
+++ b/packages/app/src/baltici/money.ts
@@ -1,0 +1,35 @@
+// Money helpers — parsing user input to integer cents and formatting back.
+
+export type ParseResult = { cents: number } | { error: ParseError };
+export type ParseError = "empty" | "invalid" | "nonpositive";
+
+/**
+ * Parse a user-typed amount (EUR) into integer cents.
+ * Accepts a comma or dot as decimal separator, max 2 decimals.
+ * Rejects empty, non-numeric, negative and zero.
+ */
+export function parseAmountToCents(raw: string): ParseResult {
+  const s = raw.trim().replace(/\s/g, "");
+  if (s === "") return { error: "empty" };
+
+  const normalized = s.replace(",", ".");
+  if (!/^\d+(\.\d{1,2})?$/.test(normalized)) return { error: "invalid" };
+
+  const cents = Math.round(parseFloat(normalized) * 100);
+  if (cents <= 0) return { error: "nonpositive" };
+  return { cents };
+}
+
+/** Format integer cents as an Italian-style euro amount, e.g. 1250 → "12,50". */
+export function formatCents(cents: number): string {
+  return (cents / 100).toLocaleString("it-IT", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/** Same but with the euro sign, e.g. "€ 12,50" (negatives → "−€ 12,50"). */
+export function formatEuro(cents: number): string {
+  const sign = cents < 0 ? "−" : "";
+  return `${sign}€ ${formatCents(Math.abs(cents))}`;
+}

--- a/packages/app/src/baltici/store.ts
+++ b/packages/app/src/baltici/store.ts
@@ -24,6 +24,11 @@ interface RawRow {
   [key: string]: unknown;
 }
 
+// The group is a singleton (D2: one group), so its `meta` row uses a FIXED id.
+// Every setGroupName upserts that same row — otherwise, while the reactive query
+// lags behind the first write, `?? id()` would mint a new row per keystroke.
+const META_ID = "ba17c100-0000-4000-8000-000000000001";
+
 function num(v: unknown, fallback = 0): number {
   return typeof v === "number" && Number.isFinite(v) ? v : fallback;
 }
@@ -81,7 +86,11 @@ export function toGroupState(data: {
     .filter((e): e is Expense => e !== null)
     .sort((a, b) => b.createdAt - a.createdAt); // newest first (list view)
 
-  const name = str((data.meta ?? [])[0]?.groupName);
+  // Singleton group row lives at META_ID; fall back to the first row for any
+  // legacy/leftover meta row so the name is read deterministically.
+  const metaRows = data.meta ?? [];
+  const metaRow = metaRows.find((r) => r.id === META_ID) ?? metaRows[0];
+  const name = str(metaRow?.groupName);
   return { name, people, expenses };
 }
 
@@ -120,6 +129,10 @@ export function useBaltici(): UseBalticiResult {
     meta: {},
   });
 
+  // A query error (e.g. denied read permissions) is a real failure — surface it
+  // via the layout's ErrorBoundary instead of rendering a misleading empty group.
+  if (error) throw new Error(error.message ?? "InstantDB query failed");
+
   const state = useMemo(
     () => toGroupState((data ?? {}) as Parameters<typeof toGroupState>[0]),
     [data]
@@ -129,12 +142,6 @@ export function useBaltici(): UseBalticiResult {
     const net = balances(state);
     return { net, totals: totals(state), settlements: simplifyDebts(net) };
   }, [state]);
-
-  const metaId = useMemo(() => {
-    const rows = ((data ?? {}) as { meta?: RawRow[] }).meta ?? [];
-    const first = rows[0]?.id;
-    return typeof first === "string" ? first : null;
-  }, [data]);
 
   const actions = useMemo<BalticiActions>(() => {
     const peopleIds = () => new Set(state.people.map((p) => p.id));
@@ -171,7 +178,9 @@ export function useBaltici(): UseBalticiResult {
 
     return {
       setGroupName(name) {
-        database.transact(database.tx.meta[metaId ?? id()].update({ groupName: name }));
+        database.transact(
+          database.tx.meta[META_ID].update({ groupName: name })
+        );
       },
       addPerson(name) {
         const trimmed = name.trim();
@@ -219,11 +228,11 @@ export function useBaltici(): UseBalticiResult {
         );
       },
     };
-  }, [state, metaId, database]);
+  }, [state, database]);
 
   return {
     isLoading,
-    error: error ? String(error.message ?? error) : null,
+    error: null, // query errors are thrown above and caught by the ErrorBoundary
     state,
     balances: derived.net,
     totals: derived.totals,

--- a/packages/app/src/baltici/store.ts
+++ b/packages/app/src/baltici/store.ts
@@ -1,0 +1,245 @@
+// Baltici — reactive store hook over InstantDB. No Context: `db` is a module
+// singleton and reactivity comes from db.useQuery. The rest of the app works on
+// the plain GroupState (model.ts), unaware of InstantDB.
+
+import { id } from "@instantdb/react";
+import { useMemo } from "react";
+import { db } from "./db";
+import { balances, simplifyDebts, totals, type Settlement } from "./calc";
+import {
+  type Expense,
+  type GroupState,
+  type Person,
+  type PersonId,
+  personIdsInExpense,
+} from "./model";
+import { pickColor } from "./colors";
+import {
+  validateExpense,
+  type ExpenseDraft,
+  type ExpenseValidationError,
+} from "./validation";
+
+interface RawRow {
+  [key: string]: unknown;
+}
+
+function num(v: unknown, fallback = 0): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+function str(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function mapExpense(r: RawRow): Expense | null {
+  const idv = r.id;
+  const payerId = r.payerId;
+  if (typeof idv !== "string" || typeof payerId !== "string") return null;
+
+  const base = {
+    id: idv,
+    description: str(r.description),
+    amountCents: num(r.amountCents),
+    payerId,
+    date: str(r.date),
+    createdAt: num(r.createdAt),
+  };
+
+  if (r.splitMode === "exact") {
+    const shares = (r.exactShares ?? {}) as Record<string, unknown>;
+    const exactShares: Record<PersonId, number> = {};
+    for (const [k, v] of Object.entries(shares)) exactShares[k] = num(v);
+    return { ...base, splitMode: "exact", exactShares };
+  }
+
+  const participants = Array.isArray(r.participants)
+    ? (r.participants.filter((x) => typeof x === "string") as PersonId[])
+    : [];
+  return { ...base, splitMode: "equal", participants };
+}
+
+/** Pure mapper: InstantDB query result → GroupState. People ordered by
+ *  createdAt (canonical), soft-deleted rows filtered out. */
+export function toGroupState(data: {
+  people?: RawRow[];
+  expenses?: RawRow[];
+  meta?: RawRow[];
+}): GroupState {
+  const people: Person[] = (data.people ?? [])
+    .filter((r) => r.deleted !== true && typeof r.id === "string")
+    .map((r) => ({
+      id: r.id as string,
+      name: str(r.name),
+      color: str(r.color, "#888"),
+      createdAt: num(r.createdAt),
+    }))
+    .sort((a, b) => a.createdAt - b.createdAt || (a.id < b.id ? -1 : 1));
+
+  const expenses: Expense[] = (data.expenses ?? [])
+    .filter((r) => r.deleted !== true)
+    .map(mapExpense)
+    .filter((e): e is Expense => e !== null)
+    .sort((a, b) => b.createdAt - a.createdAt); // newest first (list view)
+
+  const name = str((data.meta ?? [])[0]?.groupName);
+  return { name, people, expenses };
+}
+
+export interface BalticiActions {
+  setGroupName(name: string): void;
+  addPerson(name: string): void;
+  renamePerson(personId: PersonId, name: string): void;
+  /** Returns false (and does nothing) if the person is referenced by any expense. */
+  removePerson(personId: PersonId): boolean;
+  canRemovePerson(personId: PersonId): boolean;
+  addExpense(draft: ExpenseDraft): ExpenseValidationError | null;
+  updateExpense(
+    expenseId: PersonId,
+    draft: ExpenseDraft
+  ): ExpenseValidationError | null;
+  removeExpense(expenseId: string): void;
+}
+
+export interface UseBalticiResult {
+  isLoading: boolean;
+  error: string | null;
+  state: GroupState;
+  balances: Record<PersonId, number>;
+  totals: { perPerson: Record<PersonId, number>; grand: number };
+  settlements: Settlement[];
+  actions: BalticiActions;
+}
+
+export function useBaltici(): UseBalticiResult {
+  // Pages using this hook only mount when InstantDB is configured (BalticiLayout
+  // gates on isConfigured), so db is non-null here.
+  const database = db!;
+  const { isLoading, error, data } = database.useQuery({
+    people: {},
+    expenses: {},
+    meta: {},
+  });
+
+  const state = useMemo(
+    () => toGroupState((data ?? {}) as Parameters<typeof toGroupState>[0]),
+    [data]
+  );
+
+  const derived = useMemo(() => {
+    const net = balances(state);
+    return { net, totals: totals(state), settlements: simplifyDebts(net) };
+  }, [state]);
+
+  const metaId = useMemo(() => {
+    const rows = ((data ?? {}) as { meta?: RawRow[] }).meta ?? [];
+    const first = rows[0]?.id;
+    return typeof first === "string" ? first : null;
+  }, [data]);
+
+  const actions = useMemo<BalticiActions>(() => {
+    const peopleIds = () => new Set(state.people.map((p) => p.id));
+
+    const buildRow = (draft: ExpenseDraft, createdAt: number, delId?: string) => {
+      const common = {
+        description: draft.description.trim(),
+        amountCents: draft.amountCents,
+        payerId: draft.payerId,
+        date: draft.date,
+        splitMode: draft.splitMode,
+        createdAt,
+        deleted: false,
+      };
+      const full =
+        draft.splitMode === "equal"
+          ? { ...common, participants: draft.participants, exactShares: {} }
+          : { ...common, participants: [], exactShares: draft.exactShares };
+      return database.tx.expenses[delId ?? id()].update(full);
+    };
+
+    const writeExpense = (
+      draft: ExpenseDraft,
+      existingId?: string
+    ): ExpenseValidationError | null => {
+      const err = validateExpense(draft, peopleIds());
+      if (err) return err;
+      const createdAt = existingId
+        ? state.expenses.find((e) => e.id === existingId)?.createdAt ?? 0
+        : nowStamp(state);
+      database.transact(buildRow(draft, createdAt, existingId));
+      return null;
+    };
+
+    return {
+      setGroupName(name) {
+        database.transact(database.tx.meta[metaId ?? id()].update({ groupName: name }));
+      },
+      addPerson(name) {
+        const trimmed = name.trim();
+        if (trimmed === "") return;
+        database.transact(
+          database.tx.people[id()].update({
+            name: trimmed,
+            color: pickColor(state.people.length),
+            createdAt: nowStamp(state),
+            deleted: false,
+          })
+        );
+      },
+      renamePerson(personId, name) {
+        const trimmed = name.trim();
+        if (trimmed === "") return;
+        database.transact(
+          database.tx.people[personId].update({ name: trimmed })
+        );
+      },
+      canRemovePerson(personId) {
+        return !state.expenses.some((e) =>
+          personIdsInExpense(e).includes(personId)
+        );
+      },
+      removePerson(personId) {
+        const referenced = state.expenses.some((e) =>
+          personIdsInExpense(e).includes(personId)
+        );
+        if (referenced) return false;
+        database.transact(
+          database.tx.people[personId].update({ deleted: true })
+        );
+        return true;
+      },
+      addExpense(draft) {
+        return writeExpense(draft);
+      },
+      updateExpense(expenseId, draft) {
+        return writeExpense(draft, expenseId);
+      },
+      removeExpense(expenseId) {
+        database.transact(
+          database.tx.expenses[expenseId].update({ deleted: true })
+        );
+      },
+    };
+  }, [state, metaId, database]);
+
+  return {
+    isLoading,
+    error: error ? String(error.message ?? error) : null,
+    state,
+    balances: derived.net,
+    totals: derived.totals,
+    settlements: derived.settlements,
+    actions,
+  };
+}
+
+// Monotonic-ish creation stamp without Date.now() surprises in tests: newest
+// existing createdAt + 1, or a base epoch. (Real wall-clock isn't needed — only
+// a stable increasing order for canonical people ordering.)
+function nowStamp(state: GroupState): number {
+  const stamps = [
+    ...state.people.map((p) => p.createdAt),
+    ...state.expenses.map((e) => e.createdAt),
+    Date.now(),
+  ];
+  return Math.max(...stamps) + 1;
+}

--- a/packages/app/src/baltici/validation.ts
+++ b/packages/app/src/baltici/validation.ts
@@ -1,0 +1,71 @@
+// Baltici — expense validation. Pure; reused by the store (guard before writing)
+// and by unit tests. Prevents illegal states (e.g. equal split with no
+// participants → shareOf would divide by zero; exact shares not summing to total).
+
+import { type PersonId } from "./model";
+
+export interface EqualDraft {
+  splitMode: "equal";
+  description: string;
+  amountCents: number;
+  payerId: PersonId;
+  date: string;
+  participants: PersonId[];
+}
+
+export interface ExactDraft {
+  splitMode: "exact";
+  description: string;
+  amountCents: number;
+  payerId: PersonId;
+  date: string;
+  exactShares: Record<PersonId, number>;
+}
+
+export type ExpenseDraft = EqualDraft | ExactDraft;
+
+export type ExpenseValidationError =
+  | "no-description"
+  | "bad-amount"
+  | "bad-payer"
+  | "bad-date"
+  | "no-participants"
+  | "bad-participants"
+  | "bad-share-ids"
+  | "shares-negative"
+  | "shares-mismatch";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Returns null when valid, otherwise the first error found. */
+export function validateExpense(
+  draft: ExpenseDraft,
+  peopleIds: ReadonlySet<PersonId>
+): ExpenseValidationError | null {
+  if (draft.description.trim() === "") return "no-description";
+  if (!Number.isInteger(draft.amountCents) || draft.amountCents <= 0)
+    return "bad-amount";
+  if (!peopleIds.has(draft.payerId)) return "bad-payer";
+  if (!DATE_RE.test(draft.date)) return "bad-date";
+
+  if (draft.splitMode === "equal") {
+    const parts = draft.participants;
+    if (parts.length === 0) return "no-participants";
+    const unique = new Set(parts);
+    if (unique.size !== parts.length) return "bad-participants";
+    for (const id of parts) if (!peopleIds.has(id)) return "bad-participants";
+    return null;
+  }
+
+  const ids = Object.keys(draft.exactShares);
+  if (ids.length === 0) return "no-participants";
+  for (const id of ids) if (!peopleIds.has(id)) return "bad-share-ids";
+  let sum = 0;
+  for (const id of ids) {
+    const share = draft.exactShares[id];
+    if (!Number.isInteger(share) || share < 0) return "shares-negative";
+    sum += share;
+  }
+  if (sum !== draft.amountCents) return "shares-mismatch";
+  return null;
+}

--- a/packages/app/src/layouts/BalticiLayout.tsx
+++ b/packages/app/src/layouts/BalticiLayout.tsx
@@ -37,7 +37,7 @@ function BalticiLayout() {
         />
         <div style={{ width: "100%", padding: "0 12px 40px", boxSizing: "border-box" }}>
           {isConfigured ? (
-            <ErrorBoundary fallback={<NotConfigured />}>
+            <ErrorBoundary fallback={<GenericError />}>
               <Outlet />
             </ErrorBoundary>
           ) : (
@@ -67,6 +67,25 @@ function NotConfigured() {
       <code style={{ display: "block", marginTop: 12, opacity: 0.8 }}>
         VITE_INSTANT_APP_ID
       </code>
+    </div>
+  );
+}
+
+function GenericError() {
+  const { t } = useTranslation();
+  return (
+    <div
+      style={{
+        border: "1.5px solid currentColor",
+        padding: "24px",
+        margin: "24px 0",
+        font: "400 14px/1.6 'Space Mono', monospace",
+      }}
+    >
+      <strong style={{ display: "block", marginBottom: 8 }}>
+        {t("baltici.error.title")}
+      </strong>
+      {t("baltici.error.body")}
     </div>
   );
 }

--- a/packages/app/src/layouts/BalticiLayout.tsx
+++ b/packages/app/src/layouts/BalticiLayout.tsx
@@ -1,0 +1,74 @@
+import { Header, Stack } from "@gorlium/design-system";
+import { Outlet, Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { isConfigured } from "../baltici/db";
+import { ErrorBoundary } from "../baltici/components/ErrorBoundary";
+
+// Baltici area chrome — mirrors TerrariumLayout. When InstantDB isn't configured
+// (no app ID at build time) we render a short setup notice instead of the pages,
+// so their db.useQuery hooks never run against a placeholder app.
+function BalticiLayout() {
+  const { t } = useTranslation();
+
+  return (
+    <div style={{ maxWidth: "1000px", margin: "0 auto", overflow: "hidden" }}>
+      <Stack space={16} align="center">
+        <Link
+          to="/"
+          style={{
+            alignSelf: "flex-start",
+            margin: "8px 0 0 8px",
+            font: "700 11px/1 'Space Mono', monospace",
+            letterSpacing: ".16em",
+            color: "inherit",
+            textDecoration: "none",
+            opacity: 0.7,
+          }}
+        >
+          ← GORLIUM HUB
+        </Link>
+        <Header
+          list={[
+            [t("baltici.tabs.home"), "/baltici"],
+            [t("baltici.tabs.expenses"), "/baltici/expenses"],
+            [t("baltici.tabs.whoOwes"), "/baltici/who-owes"],
+            [t("baltici.tabs.people"), "/baltici/people"],
+          ]}
+        />
+        <div style={{ width: "100%", padding: "0 12px 40px", boxSizing: "border-box" }}>
+          {isConfigured ? (
+            <ErrorBoundary fallback={<NotConfigured />}>
+              <Outlet />
+            </ErrorBoundary>
+          ) : (
+            <NotConfigured />
+          )}
+        </div>
+      </Stack>
+    </div>
+  );
+}
+
+function NotConfigured() {
+  const { t } = useTranslation();
+  return (
+    <div
+      style={{
+        border: "1.5px solid currentColor",
+        padding: "24px",
+        margin: "24px 0",
+        font: "400 14px/1.6 'Space Mono', monospace",
+      }}
+    >
+      <strong style={{ display: "block", marginBottom: 8 }}>
+        {t("baltici.notConfigured.title")}
+      </strong>
+      {t("baltici.notConfigured.body")}
+      <code style={{ display: "block", marginTop: 12, opacity: 0.8 }}>
+        VITE_INSTANT_APP_ID
+      </code>
+    </div>
+  );
+}
+
+export default BalticiLayout;

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -97,6 +97,10 @@
         "title": "Baltici is not configured yet.",
         "body": "Shared data needs an InstantDB app. Create one, then set this build-time env var on Netlify and in your local .env:"
       },
+      "error": {
+        "title": "Something went wrong.",
+        "body": "Couldn't load the shared data. Check your connection and reload the page."
+      },
       "home": {
         "untitled": "Trip",
         "noPeople": "No people yet. Start by adding the group in",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -85,6 +85,77 @@
           "Put your terrarium in a bright spot, but avoid direct sunlight. Sun rays can overheat the glass and damage the plants. Indirect, diffused light is best."
         ]
       }
+    },
+    "baltici": {
+      "tabs": {
+        "home": "SUMMARY",
+        "expenses": "EXPENSES",
+        "whoOwes": "WHO OWES",
+        "people": "PEOPLE"
+      },
+      "notConfigured": {
+        "title": "Baltici is not configured yet.",
+        "body": "Shared data needs an InstantDB app. Create one, then set this build-time env var on Netlify and in your local .env:"
+      },
+      "home": {
+        "untitled": "Trip",
+        "noPeople": "No people yet. Start by adding the group in",
+        "grandTotal": "Trip total",
+        "expenses": "Expenses",
+        "balances": "Balances",
+        "hint": "See the payments to make in"
+      },
+      "people": {
+        "groupName": "Group name",
+        "groupNamePlaceholder": "e.g. Baltic trip 2026",
+        "title": "People",
+        "empty": "No one here yet. Add the people below.",
+        "add": "Add a person",
+        "name": "Name",
+        "namePlaceholder": "e.g. Marco",
+        "addButton": "ADD",
+        "remove": "REMOVE",
+        "removeBlocked": "This person has expenses linked. Remove or edit those first."
+      },
+      "expenses": {
+        "title": "Expenses",
+        "add": "+ ADD EXPENSE",
+        "empty": "No expenses yet. Add the first one.",
+        "paidBy": "paid by {{name}}",
+        "all": "everyone",
+        "edit": "EDIT",
+        "remove": "REMOVE"
+      },
+      "expense": {
+        "newTitle": "New expense",
+        "editTitle": "Edit expense",
+        "description": "Description",
+        "descriptionPlaceholder": "e.g. Dinner",
+        "amount": "Amount",
+        "payer": "Paid by",
+        "date": "Date",
+        "split": "How to split",
+        "splitAll": "Everyone",
+        "splitSubset": "Subset",
+        "splitExact": "Exact",
+        "perHead": "Split among {{count}} · € {{amount}} each",
+        "save": "SAVE",
+        "cancel": "CANCEL",
+        "needPeople": "Add some people first.",
+        "errAmount": "Enter a valid amount greater than zero.",
+        "errPayer": "Choose who paid.",
+        "errDescription": "Enter a description.",
+        "errShares": "One of the shares is not a valid amount.",
+        "errRemainder": "The shares must add up to the total.",
+        "errParticipants": "Select at least one person.",
+        "errGeneric": "Something is off with this expense."
+      },
+      "whoOwes": {
+        "title": "Who owes whom",
+        "empty": "Add people and expenses to see the balances.",
+        "allEven": "All settled — nobody owes anything.",
+        "hint": "Fewest payments to settle everything. Actual transfers happen among you."
+      }
     }
   }
 }

--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -37,7 +37,7 @@ const WORLDS: World[] = [
   { slug: "terrari", name: "Terrariums", accent: "#8faa57", desc: "Tiny worlds, sealed under glass.", img: "/gorlium/terrari.svg", href: "/terrariums", restricted: false },
   { slug: "sartoria", name: "Tailoring", accent: "#8aa0c8", desc: "Made-to-measure, from the pattern.", img: "/gorlium/sartoria.svg", href: null, restricted: false },
   { slug: "gioielleria", name: "Jewelry", accent: "#cda64e", desc: "Metal and stone, in the detail.", img: "/gorlium/gioielleria.svg", href: null, restricted: false },
-  { slug: "maglia", name: "Knitting & Crochet", accent: "#cc7a4f", desc: "Handmade, warm and slow.", img: "/gorlium/maglia.svg", href: null, restricted: false },
+  { slug: "baltici", name: "Baltici", accent: "#cc7a4f", desc: "Trip expenses, split fair.", img: "/gorlium/maglia.svg", href: "/baltici", restricted: false },
   { slug: "software", name: "Software & Development", accent: "#5fb3c6", desc: "Code, systems and experiments.", img: "/gorlium/software.svg", href: null, restricted: false },
   { slug: "mente", name: "Mental Health", accent: "#9b8cc4", desc: "A space to slow down.", img: "/gorlium/mente.svg", href: null, restricted: true },
 ];

--- a/packages/app/src/pages/baltici/BalticiAddExpense.tsx
+++ b/packages/app/src/pages/baltici/BalticiAddExpense.tsx
@@ -1,0 +1,244 @@
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { SectionTitle } from "../../baltici/components/atoms";
+import {
+  Label,
+  TextInput,
+  AmountInput,
+  DateInput,
+  PersonSelect,
+  SplitModeTabs,
+  ParticipantsToggle,
+  ExactSharesEditor,
+} from "../../baltici/components/formControls";
+import { parseAmountToCents } from "../../baltici/money";
+import type { ExpenseDraft } from "../../baltici/validation";
+import type { PersonId } from "../../baltici/model";
+
+const mono = "'Space Mono', monospace";
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Empty → 0 cents; invalid → null.
+function parseShare(raw: string): number | null {
+  if (raw.trim() === "") return 0;
+  const r = parseAmountToCents(raw);
+  return "cents" in r ? r.cents : null;
+}
+
+function BalticiAddExpense() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { id: editId } = useParams();
+  const { state, actions } = useBaltici();
+
+  const editing = editId ? state.expenses.find((e) => e.id === editId) : undefined;
+
+  const [description, setDescription] = useState(editing?.description ?? "");
+  const [amount, setAmount] = useState(
+    editing ? (editing.amountCents / 100).toFixed(2).replace(".", ",") : ""
+  );
+  const [payerId, setPayerId] = useState<PersonId | "">(editing?.payerId ?? "");
+  const [date, setDate] = useState(editing?.date ?? today());
+  const [mode, setMode] = useState<"all" | "subset" | "exact">(() => {
+    if (!editing) return "all";
+    if (editing.splitMode === "exact") return "exact";
+    return editing.participants.length === state.people.length ? "all" : "subset";
+  });
+  const [subset, setSubset] = useState<Set<PersonId>>(() => {
+    if (editing && editing.splitMode === "equal") return new Set(editing.participants);
+    return new Set(state.people.map((p) => p.id));
+  });
+  const [exactValues, setExactValues] = useState<Record<PersonId, string>>(() => {
+    const out: Record<PersonId, string> = {};
+    if (editing && editing.splitMode === "exact") {
+      for (const [k, v] of Object.entries(editing.exactShares)) {
+        out[k] = (v / 100).toFixed(2).replace(".", ",");
+      }
+    }
+    return out;
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const amountCents = useMemo(() => {
+    const r = parseAmountToCents(amount);
+    return "cents" in r ? r.cents : 0;
+  }, [amount]);
+
+  const exactSum = useMemo(() => {
+    let s = 0;
+    for (const p of state.people) {
+      const c = parseShare(exactValues[p.id] ?? "");
+      if (c && c > 0) s += c;
+    }
+    return s;
+  }, [exactValues, state.people]);
+
+  const remainder = amountCents - exactSum;
+
+  const buildDraft = (): { draft?: ExpenseDraft; error?: string } => {
+    const amt = parseAmountToCents(amount);
+    if (!("cents" in amt)) return { error: t("baltici.expense.errAmount") };
+    if (!payerId) return { error: t("baltici.expense.errPayer") };
+    if (description.trim() === "") return { error: t("baltici.expense.errDescription") };
+
+    const common = {
+      description,
+      amountCents: amt.cents,
+      payerId,
+      date,
+    };
+
+    if (mode === "exact") {
+      const exactShares: Record<PersonId, number> = {};
+      for (const p of state.people) {
+        const c = parseShare(exactValues[p.id] ?? "");
+        if (c === null) return { error: t("baltici.expense.errShares") };
+        if (c > 0) exactShares[p.id] = c;
+      }
+      if (remainder !== 0) return { error: t("baltici.expense.errRemainder") };
+      return { draft: { ...common, splitMode: "exact", exactShares } };
+    }
+
+    const participants =
+      mode === "all" ? state.people.map((p) => p.id) : [...subset];
+    if (participants.length === 0) return { error: t("baltici.expense.errParticipants") };
+    return { draft: { ...common, splitMode: "equal", participants } };
+  };
+
+  const save = () => {
+    setError(null);
+    const { draft, error: err } = buildDraft();
+    if (err || !draft) {
+      setError(err ?? t("baltici.expense.errGeneric"));
+      return;
+    }
+    const vErr = editing
+      ? actions.updateExpense(editing.id, draft)
+      : actions.addExpense(draft);
+    if (vErr) {
+      setError(t("baltici.expense.errGeneric"));
+      return;
+    }
+    navigate("/baltici/expenses");
+  };
+
+  if (state.people.length === 0) {
+    return <p style={{ font: `400 14px/1.5 ${mono}` }}>{t("baltici.expense.needPeople")}</p>;
+  }
+
+  const perHead =
+    mode !== "exact" && amountCents > 0
+      ? Math.floor(
+          amountCents / (mode === "all" ? state.people.length : Math.max(subset.size, 1))
+        )
+      : 0;
+  const headCount = mode === "all" ? state.people.length : subset.size;
+
+  return (
+    <div style={{ maxWidth: 520 }}>
+      <SectionTitle>
+        {editing ? t("baltici.expense.editTitle") : t("baltici.expense.newTitle")}
+      </SectionTitle>
+
+      <div style={{ display: "grid", gap: 14 }}>
+        <div>
+          <Label text={t("baltici.expense.description")} />
+          <TextInput value={description} onChange={setDescription} placeholder={t("baltici.expense.descriptionPlaceholder")} />
+        </div>
+
+        <div style={{ display: "flex", gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <Label text={t("baltici.expense.amount")} />
+            <AmountInput value={amount} onChange={setAmount} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <Label text={t("baltici.expense.payer")} />
+            <PersonSelect people={state.people} value={payerId} onChange={setPayerId} />
+          </div>
+        </div>
+
+        <div>
+          <Label text={t("baltici.expense.date")} />
+          <DateInput value={date} onChange={setDate} />
+        </div>
+
+        <div>
+          <Label text={t("baltici.expense.split")} />
+          <SplitModeTabs
+            value={mode}
+            labels={{
+              all: t("baltici.expense.splitAll"),
+              subset: t("baltici.expense.splitSubset"),
+              exact: t("baltici.expense.splitExact"),
+            }}
+            onChange={(v) => {
+              setMode(v);
+              if (v === "subset" && subset.size === 0) {
+                setSubset(new Set(state.people.map((p) => p.id)));
+              }
+            }}
+          />
+        </div>
+
+        {mode === "subset" && (
+          <ParticipantsToggle
+            people={state.people}
+            selected={subset}
+            onToggle={(pid) => {
+              setSubset((prev) => {
+                const next = new Set(prev);
+                if (next.has(pid)) next.delete(pid);
+                else next.add(pid);
+                return next;
+              });
+            }}
+          />
+        )}
+
+        {mode === "exact" && (
+          <ExactSharesEditor
+            people={state.people}
+            values={exactValues}
+            onChange={(pid, v) => setExactValues((prev) => ({ ...prev, [pid]: v }))}
+            remainderCents={remainder}
+          />
+        )}
+
+        {mode !== "exact" && amountCents > 0 && headCount > 0 && (
+          <div style={{ font: `400 13px/1.4 ${mono}`, opacity: 0.75 }}>
+            {t("baltici.expense.perHead", {
+              count: headCount,
+              amount: (perHead / 100).toFixed(2).replace(".", ","),
+            })}
+          </div>
+        )}
+
+        {error && <div style={{ font: `700 13px/1.4 ${mono}`, color: "#a83232" }}>{error}</div>}
+
+        <div style={{ display: "flex", gap: 10 }}>
+          <button
+            type="button"
+            onClick={save}
+            style={{ font: `700 13px/1 ${mono}`, border: "1.5px solid currentColor", background: "currentColor", color: "#ece7dd", padding: "12px 18px", cursor: "pointer" }}
+          >
+            {t("baltici.expense.save")}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/baltici/expenses")}
+            style={{ font: `400 13px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "12px 18px", cursor: "pointer" }}
+          >
+            {t("baltici.expense.cancel")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default BalticiAddExpense;

--- a/packages/app/src/pages/baltici/BalticiAddExpense.tsx
+++ b/packages/app/src/pages/baltici/BalticiAddExpense.tsx
@@ -20,7 +20,10 @@ import type { PersonId } from "../../baltici/model";
 const mono = "'Space Mono', monospace";
 
 function today(): string {
-  return new Date().toISOString().slice(0, 10);
+  // Local date (not UTC) so the default doesn't slip a day near midnight.
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 // Empty → 0 cents; invalid → null.

--- a/packages/app/src/pages/baltici/BalticiExpenses.tsx
+++ b/packages/app/src/pages/baltici/BalticiExpenses.tsx
@@ -1,0 +1,81 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { Row, EmptyState, SectionTitle } from "../../baltici/components/atoms";
+import { formatEuro } from "../../baltici/money";
+import { participantsOf, type Expense, type Person } from "../../baltici/model";
+
+const mono = "'Space Mono', monospace";
+
+function splitSummary(e: Expense, people: Person[], allLabel: string): string {
+  const parts = participantsOf(e);
+  if (e.splitMode === "equal" && parts.length === people.length) return allLabel;
+  if (e.splitMode === "exact") return `${parts.length}×`;
+  return `${parts.length}`;
+}
+
+function BalticiExpenses() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { state, actions } = useBaltici();
+
+  const nameOf = (id: string) => state.people.find((p) => p.id === id)?.name ?? "?";
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <SectionTitle>{t("baltici.expenses.title")}</SectionTitle>
+        <Link
+          to="/baltici/expenses/new"
+          style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
+        >
+          {t("baltici.expenses.add")}
+        </Link>
+      </div>
+
+      {state.expenses.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
+
+      {state.expenses.map((e) => (
+        <Row key={e.id} style={{ alignItems: "flex-start" }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ font: `700 14px/1.2 ${mono}` }}>{e.description}</div>
+            <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
+              {t("baltici.expenses.paidBy", { name: nameOf(e.payerId) })} · {e.date} ·{" "}
+              {splitSummary(e, state.people, t("baltici.expenses.all"))}
+            </div>
+          </div>
+          <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => navigate(`/baltici/expenses/${e.id}/edit`)}
+              style={btnStyle}
+              aria-label={t("baltici.expenses.edit")}
+            >
+              {t("baltici.expenses.edit")}
+            </button>
+            <button
+              type="button"
+              onClick={() => actions.removeExpense(e.id)}
+              style={btnStyle}
+              aria-label={t("baltici.expenses.remove")}
+            >
+              {t("baltici.expenses.remove")}
+            </button>
+          </div>
+        </Row>
+      ))}
+    </div>
+  );
+}
+
+const btnStyle = {
+  font: `700 11px/1 ${mono}`,
+  border: "1.5px solid currentColor",
+  background: "transparent",
+  color: "inherit",
+  padding: "6px 8px",
+  cursor: "pointer",
+} as const;
+
+export default BalticiExpenses;

--- a/packages/app/src/pages/baltici/BalticiHome.tsx
+++ b/packages/app/src/pages/baltici/BalticiHome.tsx
@@ -1,0 +1,68 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { PersonAvatar, Money, Row, EmptyState, SectionTitle } from "../../baltici/components/atoms";
+import { formatEuro } from "../../baltici/money";
+
+const mono = "'Space Mono', monospace";
+
+function BalticiHome() {
+  const { t } = useTranslation();
+  const { isLoading, state, balances, totals } = useBaltici();
+
+  if (isLoading) return <p style={{ font: `400 14px/1 ${mono}` }}>…</p>;
+
+  const title = state.name.trim() || t("baltici.home.untitled");
+
+  if (state.people.length === 0) {
+    return (
+      <div>
+        <SectionTitle>{title}</SectionTitle>
+        <EmptyState>
+          {t("baltici.home.noPeople")}{" "}
+          <Link to="/baltici/people" style={{ color: "inherit" }}>
+            {t("baltici.tabs.people")}
+          </Link>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionTitle>{title}</SectionTitle>
+
+      <div style={{ display: "flex", gap: 24, flexWrap: "wrap", margin: "8px 0 4px" }}>
+        <Stat label={t("baltici.home.grandTotal")} value={formatEuro(totals.grand)} />
+        <Stat label={t("baltici.home.expenses")} value={String(state.expenses.length)} />
+      </div>
+
+      <SectionTitle>{t("baltici.home.balances")}</SectionTitle>
+      {state.people.map((p) => (
+        <Row key={p.id}>
+          <PersonAvatar person={p} />
+          <span style={{ flex: 1, font: `400 14px/1 ${mono}` }}>{p.name}</span>
+          <Money cents={balances[p.id] ?? 0} bold />
+        </Row>
+      ))}
+
+      <p style={{ font: `400 12px/1.5 ${mono}`, opacity: 0.65, marginTop: 16 }}>
+        {t("baltici.home.hint")}{" "}
+        <Link to="/baltici/who-owes" style={{ color: "inherit" }}>
+          {t("baltici.tabs.whoOwes")}
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ font: `700 11px/1 ${mono}`, letterSpacing: ".1em", textTransform: "uppercase", opacity: 0.7 }}>{label}</div>
+      <div style={{ font: `700 22px/1.1 ${mono}`, marginTop: 4 }}>{value}</div>
+    </div>
+  );
+}
+
+export default BalticiHome;

--- a/packages/app/src/pages/baltici/BalticiPeople.tsx
+++ b/packages/app/src/pages/baltici/BalticiPeople.tsx
@@ -28,9 +28,11 @@ function BalticiPeople() {
       <div style={{ display: "flex", gap: 8 }}>
         <TextInput
           value={nameValue}
-          onChange={(v) => {
-            setGroupName(v);
-            actions.setGroupName(v);
+          onChange={setGroupName}
+          onBlur={() => {
+            if (groupName !== null && groupName !== state.name) {
+              actions.setGroupName(groupName.trim());
+            }
           }}
           placeholder={t("baltici.people.groupNamePlaceholder")}
         />
@@ -45,7 +47,13 @@ function BalticiPeople() {
             <PersonAvatar person={p} />
             <input
               defaultValue={p.name}
-              onBlur={(e) => actions.renamePerson(p.id, e.target.value)}
+              onBlur={(e) => {
+                if (e.target.value.trim() === "") {
+                  e.target.value = p.name; // don't allow clearing to empty
+                  return;
+                }
+                actions.renamePerson(p.id, e.target.value);
+              }}
               style={{ flex: 1, font: `400 14px/1 ${mono}`, border: "none", borderBottom: "1px solid transparent", background: "transparent", color: "inherit", padding: "4px 0" }}
             />
             <button

--- a/packages/app/src/pages/baltici/BalticiPeople.tsx
+++ b/packages/app/src/pages/baltici/BalticiPeople.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { PersonAvatar, Row, SectionTitle, EmptyState } from "../../baltici/components/atoms";
+import { Label, TextInput } from "../../baltici/components/formControls";
+
+const mono = "'Space Mono', monospace";
+
+function BalticiPeople() {
+  const { t } = useTranslation();
+  const { state, actions } = useBaltici();
+  const [newName, setNewName] = useState("");
+  const [groupName, setGroupName] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState<string | null>(null);
+
+  const nameValue = groupName ?? state.name;
+
+  const add = () => {
+    const n = newName.trim();
+    if (!n) return;
+    actions.addPerson(n);
+    setNewName("");
+  };
+
+  return (
+    <div>
+      <SectionTitle>{t("baltici.people.groupName")}</SectionTitle>
+      <div style={{ display: "flex", gap: 8 }}>
+        <TextInput
+          value={nameValue}
+          onChange={(v) => {
+            setGroupName(v);
+            actions.setGroupName(v);
+          }}
+          placeholder={t("baltici.people.groupNamePlaceholder")}
+        />
+      </div>
+
+      <SectionTitle>{t("baltici.people.title")}</SectionTitle>
+      {state.people.length === 0 && <EmptyState>{t("baltici.people.empty")}</EmptyState>}
+      {state.people.map((p) => {
+        const canRemove = actions.canRemovePerson(p.id);
+        return (
+          <Row key={p.id}>
+            <PersonAvatar person={p} />
+            <input
+              defaultValue={p.name}
+              onBlur={(e) => actions.renamePerson(p.id, e.target.value)}
+              style={{ flex: 1, font: `400 14px/1 ${mono}`, border: "none", borderBottom: "1px solid transparent", background: "transparent", color: "inherit", padding: "4px 0" }}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (!actions.removePerson(p.id)) setBlocked(p.id);
+              }}
+              disabled={!canRemove}
+              title={canRemove ? "" : t("baltici.people.removeBlocked")}
+              style={{
+                font: `700 11px/1 ${mono}`,
+                border: "1.5px solid currentColor",
+                background: "transparent",
+                color: "inherit",
+                padding: "6px 8px",
+                cursor: canRemove ? "pointer" : "not-allowed",
+                opacity: canRemove ? 1 : 0.4,
+              }}
+            >
+              {t("baltici.people.remove")}
+            </button>
+          </Row>
+        );
+      })}
+
+      {blocked && (
+        <p style={{ font: `400 12px/1.5 ${mono}`, color: "#a83232" }}>
+          {t("baltici.people.removeBlocked")}
+        </p>
+      )}
+
+      <SectionTitle>{t("baltici.people.add")}</SectionTitle>
+      <div style={{ display: "flex", gap: 8, alignItems: "flex-end" }}>
+        <div style={{ flex: 1 }}>
+          <Label text={t("baltici.people.name")} />
+          <TextInput
+            value={newName}
+            onChange={setNewName}
+            placeholder={t("baltici.people.namePlaceholder")}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={add}
+          style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", background: "currentColor", color: "#ece7dd", padding: "10px 14px", cursor: "pointer" }}
+        >
+          {t("baltici.people.addButton")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default BalticiPeople;

--- a/packages/app/src/pages/baltici/BalticiSettleUp.tsx
+++ b/packages/app/src/pages/baltici/BalticiSettleUp.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { Row, EmptyState, SectionTitle, PersonAvatar } from "../../baltici/components/atoms";
+import { formatEuro } from "../../baltici/money";
+import type { Person } from "../../baltici/model";
+
+const mono = "'Space Mono', monospace";
+
+function BalticiSettleUp() {
+  const { t } = useTranslation();
+  const { state, settlements } = useBaltici();
+
+  const byId = (id: string): Person | undefined => state.people.find((p) => p.id === id);
+
+  return (
+    <div>
+      <SectionTitle>{t("baltici.whoOwes.title")}</SectionTitle>
+
+      {state.people.length === 0 && <EmptyState>{t("baltici.whoOwes.empty")}</EmptyState>}
+      {state.people.length > 0 && settlements.length === 0 && (
+        <EmptyState>{t("baltici.whoOwes.allEven")}</EmptyState>
+      )}
+
+      {settlements.map((s, i) => {
+        const from = byId(s.fromId);
+        const to = byId(s.toId);
+        if (!from || !to) return null;
+        return (
+          <Row key={i}>
+            <PersonAvatar person={from} size={26} />
+            <span style={{ font: `400 14px/1 ${mono}` }}>{from.name}</span>
+            <span style={{ opacity: 0.6 }}>→</span>
+            <PersonAvatar person={to} size={26} />
+            <span style={{ flex: 1, font: `400 14px/1 ${mono}` }}>{to.name}</span>
+            <span style={{ font: `700 14px/1 ${mono}` }}>{formatEuro(s.amountCents)}</span>
+          </Row>
+        );
+      })}
+
+      <p style={{ font: `400 12px/1.5 ${mono}`, opacity: 0.65, marginTop: 16 }}>
+        {t("baltici.whoOwes.hint")}
+      </p>
+    </div>
+  );
+}
+
+export default BalticiSettleUp;

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 interface ImportMetaEnv {
   readonly VITE_TELEGRAM_BOT_TOKEN: string;
   readonly VITE_TELEGRAM_CHAT_ID: string;
+  readonly VITE_INSTANT_APP_ID?: string;
 }
 
 interface ImportMeta {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@gorlium/design-system':
         specifier: workspace:*
         version: link:../design-system
+      '@instantdb/react':
+        specifier: ^1.0.49
+        version: 1.0.49(react@18.3.1)
       '@types/react':
         specifier: 18.3.18
         version: 18.3.18
@@ -79,6 +82,9 @@ importers:
       vite:
         specifier: ^6.0.7
         version: 6.3.5(sass-embedded@1.92.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(vite@6.3.5)
 
   packages/design-system:
     dependencies:
@@ -1079,6 +1085,40 @@ packages:
     dev: false
     optional: true
 
+  /@instantdb/core@1.0.49:
+    resolution: {integrity: sha512-DigxsPBZIpn5cjadM7A3o9u1Tb7akZmJqEhaFsnOLxcW7Ewgu4em2CxJnV7A2tE7NoC/lkDE4RAOz7GlkXvbiA==}
+    dependencies:
+      '@instantdb/version': 1.0.49
+      mutative: 1.3.0
+      uuid: 11.1.1
+    dev: false
+
+  /@instantdb/react-common@1.0.49(react@18.3.1):
+    resolution: {integrity: sha512-f5r8KIKdyrZMZKAvU1svh2KMcA3fclaSuksKMRmBqLFCi024IWX1c63V7anWfcwOARBnAcZSvzgTgkK0MzEq6g==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      '@instantdb/core': 1.0.49
+      '@instantdb/version': 1.0.49
+      react: 18.3.1
+    dev: false
+
+  /@instantdb/react@1.0.49(react@18.3.1):
+    resolution: {integrity: sha512-Pljo7o+BiEG1ejwp8yBwvPptVJt1vVurpodvA78nFWLPC2xMOzBH/8qNL+kqFYVk/p8LS0reMi7a2Wf8Jf/THw==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      '@instantdb/core': 1.0.49
+      '@instantdb/react-common': 1.0.49(react@18.3.1)
+      '@instantdb/version': 1.0.49
+      eventsource: 4.1.0
+      react: 18.3.1
+    dev: false
+
+  /@instantdb/version@1.0.49:
+    resolution: {integrity: sha512-yP3qhO2U0TWyceY23uM5+t93gDYG58q2nRj5nOb5GertRkk3Yc90+xdSZl9Uw62eYctV3y7gvf5743bZK47fJQ==}
+    dev: false
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1457,6 +1497,10 @@ packages:
     dev: true
     optional: true
 
+  /@standard-schema/spec@1.1.0:
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+    dev: true
+
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
@@ -1484,6 +1528,17 @@ packages:
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
     dependencies:
       '@babel/types': 7.28.2
+    dev: true
+
+  /@types/chai@5.2.3:
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
+  /@types/deep-eql@4.0.2:
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
     dev: true
 
   /@types/estree@1.0.8:
@@ -1749,6 +1804,68 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/expect@4.1.10:
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/mocker@4.1.10(vite@6.3.5):
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.3.5(sass-embedded@1.92.0)
+    dev: true
+
+  /@vitest/pretty-format@4.1.10:
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+    dependencies:
+      tinyrainbow: 3.1.0
+    dev: true
+
+  /@vitest/runner@4.1.10:
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/snapshot@4.1.10:
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy@4.1.10:
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+    dev: true
+
+  /@vitest/utils@4.1.10:
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1800,6 +1917,11 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: true
+
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
     dev: true
 
   /balanced-match@1.0.2:
@@ -1863,6 +1985,11 @@ packages:
 
   /caniuse-lite@1.0.30001739:
     resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
+    dev: true
+
+  /chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
     dev: true
 
   /chalk@4.1.2:
@@ -1999,6 +2126,10 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
+
+  /es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
     dev: true
 
   /esbuild@0.24.2:
@@ -2190,9 +2321,32 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@4.1.0:
+    resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      eventsource-parser: 3.1.0
+    dev: false
+
+  /expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /fast-deep-equal@3.1.3:
@@ -2234,6 +2388,18 @@ packages:
         optional: true
     dependencies:
       picomatch: 4.0.3
+    dev: true
+
+  /fdir@6.5.0(picomatch@4.0.5):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.5
     dev: true
 
   /file-entry-cache@8.0.0:
@@ -2540,6 +2706,12 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2584,6 +2756,11 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /mutative@1.3.0:
+    resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
+    engines: {node: '>=14.0'}
+    dev: false
+
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
     dependencies:
@@ -2627,6 +2804,11 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
     dev: true
 
   /optionator@0.9.4:
@@ -2699,6 +2881,11 @@ packages:
 
   /picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
     dev: true
 
@@ -3181,6 +3368,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3203,6 +3394,14 @@ packages:
     deprecated: The work that was done in this beta branch won't be included in future versions
     dependencies:
       whatwg-url: 7.1.0
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
     dev: true
 
   /string-width@4.2.3:
@@ -3295,8 +3494,17 @@ packages:
       any-promise: 1.3.0
     dev: true
 
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
   /tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
+
+  /tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
     dev: true
 
   /tinyglobby@0.2.14:
@@ -3305,6 +3513,19 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+    dev: true
+
+  /tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+    dev: true
+
+  /tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /to-regex-range@5.0.1:
@@ -3499,6 +3720,11 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+    dev: false
+
   /varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
     dev: true
@@ -3554,6 +3780,71 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vitest@4.1.10(vite@6.3.5):
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@6.3.5)
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 6.3.5(sass-embedded@1.92.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+    dev: true
+
   /void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -3588,6 +3879,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /word-wrap@1.2.5:


### PR DESCRIPTION
## What

New hub area **Baltici** replacing the disabled "Knitting & Crochet" tile: split trip expenses among a group and see the current balances / who-owes-whom. Built for a vacation among 8 friends, no login.

## Scope (codex-approved)

- **Pure calc engine** (integer cents): equal / subset / exact split, canonical-order remainder distribution, net balances, greedy debt simplification, per-person + grand totals. **18 vitest tests**.
- **Persistence: InstantDB** — reactive, client-side, no login. App ID via `VITE_INSTANT_APP_ID` (public, same env pattern as the Telegram contact form). Soft-delete (permissions can forbid hard delete). Defensive `init()` so a missing/invalid app ID degrades to a "not configured" screen instead of blanking the whole site; `ErrorBoundary` around the area.
- **Reactive store hook** (`useQuery` + pure `toGroupState` mapper + `transact` actions). `removePerson` blocked when the person is referenced by any expense.
- **Pages**: Summary (balances + totals), Expenses (list + add/remove/edit), Add/Edit expense (explicit payer, split tabs, participant toggles, exact-shares editor with remainder), Who-owes, People (+ group name, avatars).
- Hub tile → `/baltici`; routes; i18n strings; env typing + `.env.example`.

## Verification

- `typecheck`, `lint`, `build` green; 18 unit tests pass.
- **Live end-to-end** against a real InstantDB app: added people + expense (120€ split among 3 → +80 / −40 / −40), who-owes (Marco→Andrea 40, Lucia→Andrea 40), soft-delete + removePerson — all correct and reactive.
- Robustness: an invalid `VITE_INSTANT_APP_ID` no longer blanks the site (verified).

## Deploy note

Set `VITE_INSTANT_APP_ID` in the Netlify build environment (done) and re-deploy. Recommended InstantDB permissions: `view/create/update = "true"`, `delete = "false"`.

## Plans

- `PLAN-baltici-splitwise.md` — feature scope / user stories.
- `PLAN-baltici-implementation.md` — technical plan (codex-review APPROVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)