### PR TITLE
fix(baltici): readable filled buttons/tabs (dark text on light)

### DIFF
--- a/packages/app/src/baltici/components/atoms.tsx
+++ b/packages/app/src/baltici/components/atoms.tsx
@@ -4,6 +4,12 @@ import { formatEuro } from "../money";
 
 const mono = "'Space Mono', monospace";
 
+// The Baltici area renders light text on a dark background, so a "filled"
+// (active/primary) control must be light-bg + dark-text — using currentColor for
+// both would be light-on-light and invisible.
+export const PAPER = "#ece7dd";
+export const INK = "#15140f";
+
 export function PersonAvatar({ person, size = 30 }: { person: Person; size?: number }) {
   const initial = person.name.trim().charAt(0).toUpperCase() || "?";
   return (

--- a/packages/app/src/baltici/components/formControls.tsx
+++ b/packages/app/src/baltici/components/formControls.tsx
@@ -1,5 +1,6 @@
 import type { Person, PersonId } from "../model";
 import { formatEuro } from "../money";
+import { PAPER, INK } from "./atoms";
 
 const mono = "'Space Mono', monospace";
 
@@ -133,8 +134,8 @@ export function SplitModeTabs({
               font: `${on ? 700 : 400} 12px/1 ${mono}`,
               padding: "8px 4px",
               border: "1.5px solid currentColor",
-              background: on ? "currentColor" : "transparent",
-              color: on ? "#ece7dd" : "inherit",
+              background: on ? PAPER : "transparent",
+              color: on ? INK : "inherit",
               cursor: "pointer",
             }}
           >
@@ -172,8 +173,8 @@ export function ParticipantsToggle({
               font: `${on ? 700 : 400} 13px/1 ${mono}`,
               padding: "8px 10px",
               border: "1.5px solid currentColor",
-              background: on ? "currentColor" : "transparent",
-              color: on ? "#ece7dd" : "inherit",
+              background: on ? PAPER : "transparent",
+              color: on ? INK : "inherit",
               opacity: on ? 1 : 0.6,
               cursor: "pointer",
             }}

--- a/packages/app/src/pages/baltici/BalticiAddExpense.tsx
+++ b/packages/app/src/pages/baltici/BalticiAddExpense.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
-import { SectionTitle } from "../../baltici/components/atoms";
+import { SectionTitle, PAPER, INK } from "../../baltici/components/atoms";
 import {
   Label,
   TextInput,
@@ -227,7 +227,7 @@ function BalticiAddExpense() {
           <button
             type="button"
             onClick={save}
-            style={{ font: `700 13px/1 ${mono}`, border: "1.5px solid currentColor", background: "currentColor", color: "#ece7dd", padding: "12px 18px", cursor: "pointer" }}
+            style={{ font: `700 13px/1 ${mono}`, border: `1.5px solid ${PAPER}`, background: PAPER, color: INK, padding: "12px 18px", cursor: "pointer" }}
           >
             {t("baltici.expense.save")}
           </button>

--- a/packages/app/src/pages/baltici/BalticiPeople.tsx
+++ b/packages/app/src/pages/baltici/BalticiPeople.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
-import { PersonAvatar, Row, SectionTitle, EmptyState } from "../../baltici/components/atoms";
+import { PersonAvatar, Row, SectionTitle, EmptyState, PAPER, INK } from "../../baltici/components/atoms";
 import { Label, TextInput } from "../../baltici/components/formControls";
 
 const mono = "'Space Mono', monospace";
@@ -98,7 +98,7 @@ function BalticiPeople() {
         <button
           type="button"
           onClick={add}
-          style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", background: "currentColor", color: "#ece7dd", padding: "10px 14px", cursor: "pointer" }}
+          style={{ font: `700 12px/1 ${mono}`, border: `1.5px solid ${PAPER}`, background: PAPER, color: INK, padding: "10px 14px", cursor: "pointer" }}
         >
           {t("baltici.people.addButton")}
         </button>


### PR DESCRIPTION
## Problem

In the Baltici area (light text on a dark background), "filled" controls used `background: currentColor` + `color: #ece7dd` — both light — so their labels were **invisible**: the active split tab (Everyone/Subset/Exact), selected participant toggles, and the SAVE / ADD buttons.

## Fix

Introduce shared `PAPER` (light) + `INK` (dark) constants in `baltici/components/atoms.tsx` and use them for filled controls: **light background + dark text**. Unfilled controls (transparent + light text + border) were already fine.

Touched: `formControls.tsx` (SplitModeTabs, ParticipantsToggle), `BalticiAddExpense.tsx` (SAVE), `BalticiPeople.tsx` (ADD).

## Verification

- typecheck / lint / build green, 18 tests pass.
- Verified in the browser: "Everyone"/"Subset" active tabs, all participant toggles, and SAVE/ADD now show dark, legible labels on the light fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)