### PR TITLE
feat(baltici): move to /secret-baltici, unlink from hub

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,7 +25,7 @@ function App() {
           <Route path="contacts" element={<Contacts />} />
           <Route path="dev" element={<Dev />} />
         </Route>
-        <Route path="/baltici" element={<BalticiLayout />}>
+        <Route path="/secret-baltici" element={<BalticiLayout />}>
           <Route index element={<BalticiHome />} />
           <Route path="expenses" element={<BalticiExpenses />} />
           <Route path="expenses/new" element={<BalticiAddExpense />} />

--- a/packages/app/src/layouts/BalticiLayout.tsx
+++ b/packages/app/src/layouts/BalticiLayout.tsx
@@ -29,10 +29,10 @@ function BalticiLayout() {
         </Link>
         <Header
           list={[
-            [t("baltici.tabs.home"), "/baltici"],
-            [t("baltici.tabs.expenses"), "/baltici/expenses"],
-            [t("baltici.tabs.whoOwes"), "/baltici/who-owes"],
-            [t("baltici.tabs.people"), "/baltici/people"],
+            [t("baltici.tabs.home"), "/secret-baltici"],
+            [t("baltici.tabs.expenses"), "/secret-baltici/expenses"],
+            [t("baltici.tabs.whoOwes"), "/secret-baltici/who-owes"],
+            [t("baltici.tabs.people"), "/secret-baltici/people"],
           ]}
         />
         <div style={{ width: "100%", padding: "0 12px 40px", boxSizing: "border-box" }}>

--- a/packages/app/src/pages/Hub.tsx
+++ b/packages/app/src/pages/Hub.tsx
@@ -37,7 +37,7 @@ const WORLDS: World[] = [
   { slug: "terrari", name: "Terrariums", accent: "#8faa57", desc: "Tiny worlds, sealed under glass.", img: "/gorlium/terrari.svg", href: "/terrariums", restricted: false },
   { slug: "sartoria", name: "Tailoring", accent: "#8aa0c8", desc: "Made-to-measure, from the pattern.", img: "/gorlium/sartoria.svg", href: null, restricted: false },
   { slug: "gioielleria", name: "Jewelry", accent: "#cda64e", desc: "Metal and stone, in the detail.", img: "/gorlium/gioielleria.svg", href: null, restricted: false },
-  { slug: "baltici", name: "Baltici", accent: "#cc7a4f", desc: "Trip expenses, split fair.", img: "/gorlium/maglia.svg", href: "/baltici", restricted: false },
+  { slug: "maglia", name: "Knitting & Crochet", accent: "#cc7a4f", desc: "Handmade, warm and slow.", img: "/gorlium/maglia.svg", href: null, restricted: false },
   { slug: "software", name: "Software & Development", accent: "#5fb3c6", desc: "Code, systems and experiments.", img: "/gorlium/software.svg", href: null, restricted: false },
   { slug: "mente", name: "Mental Health", accent: "#9b8cc4", desc: "A space to slow down.", img: "/gorlium/mente.svg", href: null, restricted: true },
 ];

--- a/packages/app/src/pages/baltici/BalticiAddExpense.tsx
+++ b/packages/app/src/pages/baltici/BalticiAddExpense.tsx
@@ -127,7 +127,7 @@ function BalticiAddExpense() {
       setError(t("baltici.expense.errGeneric"));
       return;
     }
-    navigate("/baltici/expenses");
+    navigate("/secret-baltici/expenses");
   };
 
   if (state.people.length === 0) {
@@ -233,7 +233,7 @@ function BalticiAddExpense() {
           </button>
           <button
             type="button"
-            onClick={() => navigate("/baltici/expenses")}
+            onClick={() => navigate("/secret-baltici/expenses")}
             style={{ font: `400 13px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "12px 18px", cursor: "pointer" }}
           >
             {t("baltici.expense.cancel")}

--- a/packages/app/src/pages/baltici/BalticiExpenses.tsx
+++ b/packages/app/src/pages/baltici/BalticiExpenses.tsx
@@ -26,7 +26,7 @@ function BalticiExpenses() {
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <SectionTitle>{t("baltici.expenses.title")}</SectionTitle>
         <Link
-          to="/baltici/expenses/new"
+          to="/secret-baltici/expenses/new"
           style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
         >
           {t("baltici.expenses.add")}
@@ -48,7 +48,7 @@ function BalticiExpenses() {
           <div style={{ display: "flex", gap: 6 }}>
             <button
               type="button"
-              onClick={() => navigate(`/baltici/expenses/${e.id}/edit`)}
+              onClick={() => navigate(`/secret-baltici/expenses/${e.id}/edit`)}
               style={btnStyle}
               aria-label={t("baltici.expenses.edit")}
             >

--- a/packages/app/src/pages/baltici/BalticiHome.tsx
+++ b/packages/app/src/pages/baltici/BalticiHome.tsx
@@ -20,7 +20,7 @@ function BalticiHome() {
         <SectionTitle>{title}</SectionTitle>
         <EmptyState>
           {t("baltici.home.noPeople")}{" "}
-          <Link to="/baltici/people" style={{ color: "inherit" }}>
+          <Link to="/secret-baltici/people" style={{ color: "inherit" }}>
             {t("baltici.tabs.people")}
           </Link>
         </EmptyState>
@@ -48,7 +48,7 @@ function BalticiHome() {
 
       <p style={{ font: `400 12px/1.5 ${mono}`, opacity: 0.65, marginTop: 16 }}>
         {t("baltici.home.hint")}{" "}
-        <Link to="/baltici/who-owes" style={{ color: "inherit" }}>
+        <Link to="/secret-baltici/who-owes" style={{ color: "inherit" }}>
           {t("baltici.tabs.whoOwes")}
         </Link>
       </p>


### PR DESCRIPTION
## What

- The Baltici area moves from `/baltici` to **`/secret-baltici`** — reachable only by direct URL. Route path and every internal link/navigation updated.
- The homepage hub tile reverts to the original **disabled "Knitting & Crochet"** (no link), i.e. exactly as before Baltici shipped.

Data is untouched: the InstantDB app id isn't tied to the URL, so existing group/people/expenses stay intact at the new path.

## Verification (browser)

- Homepage: "Knitting & Crochet" shows disabled again, no "Baltici" tile.
- `/secret-baltici`: loads with the real data; all tabs and internal links point to `/secret-baltici`.
- `/baltici`: no longer matches any route (blank).
- typecheck / lint / build green, 18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)