### PR TITLE
feat(baltici): secret word to edit/delete expenses

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -13,3 +13,9 @@ VITE_TELEGRAM_CHAT_ID=your-chat-id-here
 # (view/create/update = "true", delete = "false"). Without this, the Baltici area
 # shows a "not configured" screen; the rest of the site is unaffected.
 VITE_INSTANT_APP_ID=your-instantdb-app-id-here
+
+# Baltici — secret word required to EDIT or DELETE an expense (adding stays open).
+# Kept here (not in source) so it isn't committed to the public repo. NOTE: it is
+# still embedded in the built JS bundle, so treat it as a light guard against
+# accidental/casual edits, not real security. If unset, editing is open to everyone.
+VITE_BALTICI_EDIT_SECRET=your-secret-word-here

--- a/packages/app/src/baltici/editGate.ts
+++ b/packages/app/src/baltici/editGate.ts
@@ -1,0 +1,55 @@
+// Baltici — edit gate (logic only; UI lives in editGateUI.tsx). A fixed secret
+// word guards editing and deleting expenses; only people who know it can edit,
+// everyone can still add. This is a client-side guard-rail, NOT real auth: the
+// app has no login and the bundle is public, so a determined person could still
+// change data via the API — it's a soft barrier against accidental/casual edits.
+//
+// The word is a build-time constant (VITE_BALTICI_EDIT_SECRET), so it lives on
+// Netlify rather than in the public source, and isn't editable from the app.
+// When the env var is unset the gate is inactive (editing open) — a safe local
+// default. Unlock is session-only (in-memory): reloading the tab re-locks.
+
+import { createContext, useContext } from "react";
+
+/** The fixed secret word. Empty (env var unset) → gate inactive. */
+export const EDIT_SECRET = (import.meta.env.VITE_BALTICI_EDIT_SECRET ?? "").trim();
+
+interface GateCtx {
+  unlocked: boolean;
+  setUnlocked: (v: boolean) => void;
+}
+export const EditGateContext = createContext<GateCtx>({
+  unlocked: false,
+  setUnlocked: () => {},
+});
+
+export interface EditGate {
+  /** A secret word is set → editing/deleting expenses is protected. */
+  gateActive: boolean;
+  /** No gate, or unlocked this session → edit/delete allowed. */
+  canEdit: boolean;
+  unlocked: boolean;
+  /** Unlocks for the session if `word` matches the secret; returns whether it did. */
+  tryUnlock: (word: string) => boolean;
+  lock: () => void;
+}
+
+/** The fixed secret word combined with the session unlock state. */
+export function useEditGate(): EditGate {
+  const ctx = useContext(EditGateContext);
+  const secret = EDIT_SECRET;
+  const gateActive = secret !== "";
+  return {
+    gateActive,
+    canEdit: !gateActive || ctx.unlocked,
+    unlocked: ctx.unlocked,
+    tryUnlock: (word) => {
+      if (secret !== "" && word.trim() === secret) {
+        ctx.setUnlocked(true);
+        return true;
+      }
+      return false;
+    },
+    lock: () => ctx.setUnlocked(false),
+  };
+}

--- a/packages/app/src/baltici/editGate.ts
+++ b/packages/app/src/baltici/editGate.ts
@@ -31,7 +31,6 @@ export interface EditGate {
   unlocked: boolean;
   /** Unlocks for the session if `word` matches the secret; returns whether it did. */
   tryUnlock: (word: string) => boolean;
-  lock: () => void;
 }
 
 /** The fixed secret word combined with the session unlock state. */
@@ -50,6 +49,5 @@ export function useEditGate(): EditGate {
       }
       return false;
     },
-    lock: () => ctx.setUnlocked(false),
   };
 }

--- a/packages/app/src/baltici/editGateUI.tsx
+++ b/packages/app/src/baltici/editGateUI.tsx
@@ -1,0 +1,94 @@
+// Baltici — edit gate UI: the session provider and the unlock prompt.
+
+import { useMemo, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { EditGateContext, useEditGate } from "./editGate";
+import { PAPER, INK } from "./components/atoms";
+
+const mono = "'Space Mono', monospace";
+
+export function EditGateProvider({ children }: { children: ReactNode }) {
+  // Session-only unlock: plain in-memory state, so it resets on reload/new tab.
+  const [unlocked, setUnlocked] = useState(false);
+  const value = useMemo(() => ({ unlocked, setUnlocked }), [unlocked]);
+  return (
+    <EditGateContext.Provider value={value}>{children}</EditGateContext.Provider>
+  );
+}
+
+/** Prompt to unlock editing. Renders nothing when there's no gate or already
+ *  unlocked, so call sites can drop it in unconditionally. */
+export function UnlockBar() {
+  const { t } = useTranslation();
+  const gate = useEditGate();
+  const [word, setWord] = useState("");
+  const [error, setError] = useState(false);
+
+  if (!gate.gateActive || gate.unlocked) return null;
+
+  const submit = () => {
+    if (gate.tryUnlock(word)) {
+      setWord("");
+      setError(false);
+    } else {
+      setError(true);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        border: "1.5px solid currentColor",
+        padding: "12px 14px",
+        margin: "0 0 16px",
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      <span style={{ font: `700 12px/1.4 ${mono}` }}>🔒 {t("baltici.protection.locked")}</span>
+      <input
+        type="password"
+        value={word}
+        placeholder={t("baltici.protection.wordPlaceholder")}
+        onChange={(e) => {
+          setWord(e.target.value);
+          setError(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+        }}
+        style={{
+          font: `400 13px/1 ${mono}`,
+          padding: "8px 10px",
+          border: "1.5px solid currentColor",
+          background: "transparent",
+          color: "inherit",
+          flex: 1,
+          minWidth: 120,
+          boxSizing: "border-box",
+        }}
+      />
+      <button
+        type="button"
+        onClick={submit}
+        style={{
+          font: `700 12px/1 ${mono}`,
+          border: `1.5px solid ${PAPER}`,
+          background: PAPER,
+          color: INK,
+          padding: "9px 14px",
+          cursor: "pointer",
+        }}
+      >
+        {t("baltici.protection.unlock")}
+      </button>
+      {error && (
+        <span style={{ font: `700 12px/1 ${mono}`, color: "#a83232", width: "100%" }}>
+          {t("baltici.protection.wrong")}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/layouts/BalticiLayout.tsx
+++ b/packages/app/src/layouts/BalticiLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { isConfigured } from "../baltici/db";
 import { ErrorBoundary } from "../baltici/components/ErrorBoundary";
+import { EditGateProvider } from "../baltici/editGateUI";
 
 // Baltici area chrome — mirrors TerrariumLayout. When InstantDB isn't configured
 // (no app ID at build time) we render a short setup notice instead of the pages,
@@ -38,7 +39,9 @@ function BalticiLayout() {
         <div style={{ width: "100%", padding: "0 12px 40px", boxSizing: "border-box" }}>
           {isConfigured ? (
             <ErrorBoundary fallback={<GenericError />}>
-              <Outlet />
+              <EditGateProvider>
+                <Outlet />
+              </EditGateProvider>
             </ErrorBoundary>
           ) : (
             <NotConfigured />

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -159,6 +159,13 @@
         "empty": "Add people and expenses to see the balances.",
         "allEven": "All settled — nobody owes anything.",
         "hint": "Fewest payments to settle everything. Actual transfers happen among you."
+      },
+      "protection": {
+        "locked": "Editing is locked — enter the secret word.",
+        "editNote": "Enter the secret word to edit or delete this expense. Adding expenses is always open.",
+        "wordPlaceholder": "Secret word",
+        "unlock": "UNLOCK",
+        "wrong": "Wrong word."
       }
     }
   }

--- a/packages/app/src/pages/baltici/BalticiAddExpense.tsx
+++ b/packages/app/src/pages/baltici/BalticiAddExpense.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
+import { useEditGate } from "../../baltici/editGate";
+import { UnlockBar } from "../../baltici/editGateUI";
 import { SectionTitle, PAPER, INK } from "../../baltici/components/atoms";
 import {
   Label,
@@ -38,6 +40,7 @@ function BalticiAddExpense() {
   const navigate = useNavigate();
   const { id: editId } = useParams();
   const { state, actions } = useBaltici();
+  const gate = useEditGate();
 
   const editing = editId ? state.expenses.find((e) => e.id === editId) : undefined;
 
@@ -132,6 +135,26 @@ function BalticiAddExpense() {
 
   if (state.people.length === 0) {
     return <p style={{ font: `400 14px/1.5 ${mono}` }}>{t("baltici.expense.needPeople")}</p>;
+  }
+
+  // Editing an existing expense is gated by the secret word; adding a new one is free.
+  if (editing && !gate.canEdit) {
+    return (
+      <div style={{ maxWidth: 520 }}>
+        <SectionTitle>{t("baltici.expense.editTitle")}</SectionTitle>
+        <UnlockBar />
+        <p style={{ font: `400 13px/1.5 ${mono}`, opacity: 0.75 }}>
+          {t("baltici.protection.editNote")}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/secret-baltici/expenses")}
+          style={{ font: `400 13px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "12px 18px", cursor: "pointer", marginTop: 8 }}
+        >
+          {t("baltici.expense.cancel")}
+        </button>
+      </div>
+    );
   }
 
   const perHead =

--- a/packages/app/src/pages/baltici/BalticiExpenses.tsx
+++ b/packages/app/src/pages/baltici/BalticiExpenses.tsx
@@ -1,6 +1,8 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
+import { useEditGate } from "../../baltici/editGate";
+import { UnlockBar } from "../../baltici/editGateUI";
 import { Row, EmptyState, SectionTitle } from "../../baltici/components/atoms";
 import { formatEuro } from "../../baltici/money";
 import { participantsOf, type Expense, type Person } from "../../baltici/model";
@@ -18,6 +20,7 @@ function BalticiExpenses() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { state, actions } = useBaltici();
+  const gate = useEditGate();
 
   const nameOf = (id: string) => state.people.find((p) => p.id === id)?.name ?? "?";
 
@@ -33,6 +36,8 @@ function BalticiExpenses() {
         </Link>
       </div>
 
+      <UnlockBar />
+
       {state.expenses.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
 
       {state.expenses.map((e) => (
@@ -45,24 +50,26 @@ function BalticiExpenses() {
             </div>
           </div>
           <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
-          <div style={{ display: "flex", gap: 6 }}>
-            <button
-              type="button"
-              onClick={() => navigate(`/secret-baltici/expenses/${e.id}/edit`)}
-              style={btnStyle}
-              aria-label={t("baltici.expenses.edit")}
-            >
-              {t("baltici.expenses.edit")}
-            </button>
-            <button
-              type="button"
-              onClick={() => actions.removeExpense(e.id)}
-              style={btnStyle}
-              aria-label={t("baltici.expenses.remove")}
-            >
-              {t("baltici.expenses.remove")}
-            </button>
-          </div>
+          {gate.canEdit && (
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                type="button"
+                onClick={() => navigate(`/secret-baltici/expenses/${e.id}/edit`)}
+                style={btnStyle}
+                aria-label={t("baltici.expenses.edit")}
+              >
+                {t("baltici.expenses.edit")}
+              </button>
+              <button
+                type="button"
+                onClick={() => actions.removeExpense(e.id)}
+                style={btnStyle}
+                aria-label={t("baltici.expenses.remove")}
+              >
+                {t("baltici.expenses.remove")}
+              </button>
+            </div>
+          )}
         </Row>
       ))}
     </div>

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -3,6 +3,7 @@ interface ImportMetaEnv {
   readonly VITE_TELEGRAM_BOT_TOKEN: string;
   readonly VITE_TELEGRAM_CHAT_ID: string;
   readonly VITE_INSTANT_APP_ID?: string;
+  readonly VITE_BALTICI_EDIT_SECRET?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What

A **fixed secret word** now gates **editing and deleting** expenses in the Baltici area. **Adding** a new expense stays open to everyone.

- The word is a build-time env var `VITE_BALTICI_EDIT_SECRET` (same pattern as `VITE_INSTANT_APP_ID`) — not stored in InstantDB, not editable from the app, not committed to the public source.
- **Unlock is session-only** (in-memory): enter the word once, stays unlocked until the tab reloads/closes.
- When the env var is **unset**, the gate is **inactive** (editing open) — a safe local/default degrade.

## Why a guard-rail, not real security
The app has no login and reads are public; the word is embedded in the served JS bundle. So it's a **soft barrier against accidental/casual edits**, not cryptographic protection. In practice, since only the owner knows the word, only they can edit/delete — others can only add.

## Changes
- `baltici/editGate.ts` — `EDIT_SECRET` constant + `useEditGate()` (secret + session unlock state)
- `baltici/editGateUI.tsx` — `EditGateProvider` (session state) + `UnlockBar` prompt
- `layouts/BalticiLayout.tsx` — wrap `<Outlet/>` in the provider
- `pages/baltici/BalticiExpenses.tsx` — hide EDIT/REMOVE while locked, show `UnlockBar`
- `pages/baltici/BalticiAddExpense.tsx` — gate the edit view (incl. direct `/…/edit` URL) behind the word
- i18n keys, `vite-env.d.ts` typing, `.env.example` docs

## Deploy step
Set `VITE_BALTICI_EDIT_SECRET` in Netlify build env, then redeploy. Without it the gate stays off.

## Verification
Typecheck + lint (0 warnings) + 18 unit tests + build all green. Manually verified end-to-end against real data (zero DB writes): locked-by-default, wrong word rejected, correct word unlocks EDIT/REMOVE, direct edit-URL gated, edit form shown once unlocked, People page clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)