### PR TITLE
feat(baltici): two-phase settle-up (claim + secret-word confirmation)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import BalticiHome from "./pages/baltici/BalticiHome";
 import BalticiExpenses from "./pages/baltici/BalticiExpenses";
 import BalticiAddExpense from "./pages/baltici/BalticiAddExpense";
 import BalticiSettleUp from "./pages/baltici/BalticiSettleUp";
+import BalticiSettledDebts from "./pages/baltici/BalticiSettledDebts";
 import BalticiPeople from "./pages/baltici/BalticiPeople";
 
 function App() {
@@ -31,6 +32,7 @@ function App() {
           <Route path="expenses/new" element={<BalticiAddExpense />} />
           <Route path="expenses/:id/edit" element={<BalticiAddExpense />} />
           <Route path="who-owes" element={<BalticiSettleUp />} />
+          <Route path="settled" element={<BalticiSettledDebts />} />
           <Route path="people" element={<BalticiPeople />} />
         </Route>
       </Routes>

--- a/packages/app/src/baltici/calc.test.ts
+++ b/packages/app/src/baltici/calc.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { shareOf, balances, totals, simplifyDebts } from "./calc";
 import type { EqualExpense, ExactExpense, GroupState, Payment, Person } from "./model";
 import { parseAmountToCents, formatCents } from "./money";
-import { validateExpense } from "./validation";
+import { validateExpense, validatePayment } from "./validation";
 
 function person(id: string, i: number): Person {
   return { id, name: id, color: "#000", createdAt: i };
@@ -269,5 +269,37 @@ describe("validateExpense", () => {
         ids
       )
     ).toBe("bad-payer");
+  });
+});
+
+describe("validatePayment", () => {
+  const ids = new Set(["a", "b", "c"]);
+  const draft = { fromId: "b", toId: "a", amountCents: 300, method: "cash" };
+
+  it("accepts a valid claim", () => {
+    expect(validatePayment(draft, ids, [])).toBeNull();
+  });
+
+  it("rejects unknown people and self-payments", () => {
+    expect(validatePayment({ ...draft, fromId: "z" }, ids, [])).toBe("bad-people");
+    expect(validatePayment({ ...draft, toId: "z" }, ids, [])).toBe("bad-people");
+    expect(validatePayment({ ...draft, toId: "b" }, ids, [])).toBe("bad-people");
+  });
+
+  it("rejects non-positive or fractional amounts", () => {
+    expect(validatePayment({ ...draft, amountCents: 0 }, ids, [])).toBe("bad-amount");
+    expect(validatePayment({ ...draft, amountCents: -5 }, ids, [])).toBe("bad-amount");
+    expect(validatePayment({ ...draft, amountCents: 10.5 }, ids, [])).toBe("bad-amount");
+  });
+
+  it("rejects an empty method", () => {
+    expect(validatePayment({ ...draft, method: "  " }, ids, [])).toBe("no-method");
+  });
+
+  it("rejects a second PENDING claim for the same pair, but allows one after a confirmed", () => {
+    expect(validatePayment(draft, ids, [payment("b", "a", 100, "pending")])).toBe("duplicate-pending");
+    expect(validatePayment(draft, ids, [payment("b", "a", 100, "confirmed")])).toBeNull();
+    // different pair is fine even with a pending one around
+    expect(validatePayment({ ...draft, fromId: "c" }, ids, [payment("b", "a", 100, "pending")])).toBeNull();
   });
 });

--- a/packages/app/src/baltici/calc.test.ts
+++ b/packages/app/src/baltici/calc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { shareOf, balances, totals, simplifyDebts } from "./calc";
-import type { EqualExpense, ExactExpense, GroupState, Person } from "./model";
+import type { EqualExpense, ExactExpense, GroupState, Payment, Person } from "./model";
 import { parseAmountToCents, formatCents } from "./money";
 import { validateExpense } from "./validation";
 
@@ -24,6 +24,15 @@ function equal(over: string[], amount: number, payer = "a"): EqualExpense {
     splitMode: "equal",
     participants: over,
   };
+}
+
+function payment(
+  from: string,
+  to: string,
+  amount: number,
+  status: Payment["status"]
+): Payment {
+  return { id: "p", fromId: from, toId: to, amountCents: amount, method: "cash", status, createdAt: 0 };
 }
 
 describe("shareOf — equal split", () => {
@@ -90,6 +99,7 @@ describe("balances", () => {
           participants: people.map((p) => p.id),
         },
       ],
+      payments: [],
     };
     const net = balances(state);
     expect(net["0"]).toBe(12000 - 1500);
@@ -113,9 +123,53 @@ describe("balances", () => {
         participants,
       };
     });
-    const net = balances({ name: "t", people, expenses });
+    const net = balances({ name: "t", people, expenses, payments: [] });
     const sum = Object.values(net).reduce((a, b) => a + b, 0);
     expect(sum).toBe(0);
+  });
+});
+
+describe("balances — payments (settle-up)", () => {
+  // a pays 900 split among a,b,c → a +600, b −300, c −300
+  const base: GroupState = {
+    name: "t",
+    people: PEOPLE,
+    expenses: [equal(["a", "b", "c"], 900, "a")],
+    payments: [],
+  };
+
+  it("a pending payment has no effect (debt stays counted)", () => {
+    const net = balances({ ...base, payments: [payment("b", "a", 300, "pending")] });
+    expect(net).toEqual({ a: 600, b: -300, c: -300 });
+  });
+
+  it("a confirmed payment offsets the debt as a transfer", () => {
+    const net = balances({ ...base, payments: [payment("b", "a", 300, "confirmed")] });
+    expect(net).toEqual({ a: 300, b: 0, c: -300 });
+  });
+
+  it("sum of balances stays 0 with confirmed payments", () => {
+    const net = balances({ ...base, payments: [payment("b", "a", 300, "confirmed"), payment("c", "a", 120, "confirmed")] });
+    expect(Object.values(net).reduce((x, y) => x + y, 0)).toBe(0);
+  });
+
+  it("confirming a frozen snapshot larger than the current debt pushes the debtor into credit", () => {
+    // b's debt shrank to 100 (b paid a 600 expense split over a,b,c after claiming),
+    // but the frozen 300 claim is confirmed: b really handed 300 over.
+    const state: GroupState = {
+      ...base,
+      expenses: [...base.expenses, equal(["a", "b", "c"], 600, "b")],
+      payments: [payment("b", "a", 300, "confirmed")],
+    };
+    const net = balances(state);
+    expect(net.b).toBe(-300 - 200 + 600 + 300); // shares −300−200, paid 600, transfer +300
+    expect(net.b).toBeGreaterThan(0);
+    expect(Object.values(net).reduce((x, y) => x + y, 0)).toBe(0);
+  });
+
+  it("totals (trip total) ignore payments — a settle-up is not an expense", () => {
+    const withPay = { ...base, payments: [payment("b", "a", 300, "confirmed")] };
+    expect(totals(withPay)).toEqual(totals(base));
   });
 });
 
@@ -125,6 +179,7 @@ describe("totals", () => {
       name: "t",
       people: PEOPLE,
       expenses: [equal(["a", "b", "c"], 900, "a"), equal(["a", "b"], 200, "b")],
+      payments: [],
     };
     const { perPerson, grand } = totals(state);
     expect(perPerson.a).toBe(900);

--- a/packages/app/src/baltici/calc.ts
+++ b/packages/app/src/baltici/calc.ts
@@ -59,9 +59,16 @@ export function shareOf(
 }
 
 /**
- * Net balance per person over all expenses, in cents.
- * net = sum(paid as payer) − sum(owed shares).
+ * Net balance per person over all expenses and CONFIRMED payments, in cents.
+ * net = sum(paid as payer) − sum(owed shares) + settled transfers.
  * > 0 → in credit (the group owes them), < 0 → in debt.
+ *
+ * A confirmed payment is a transfer from → to: the debtor handed money over
+ * (their balance rises toward zero), the creditor received it (theirs falls).
+ * Pending payments have no effect — the debt stays counted until confirmed.
+ * If new expenses shrank the debt below the frozen snapshot before the claim
+ * was confirmed, the transfer can push the debtor into credit — correct, since
+ * that amount really changed hands.
  */
 export function balances(state: GroupState): Record<PersonId, number> {
   const net: Record<PersonId, number> = {};
@@ -73,6 +80,12 @@ export function balances(state: GroupState): Record<PersonId, number> {
     for (const [pid, share] of Object.entries(shares)) {
       net[pid] = (net[pid] ?? 0) - share;
     }
+  }
+
+  for (const pay of state.payments) {
+    if (pay.status !== "confirmed") continue;
+    net[pay.fromId] = (net[pay.fromId] ?? 0) + pay.amountCents;
+    net[pay.toId] = (net[pay.toId] ?? 0) - pay.amountCents;
   }
   return net;
 }

--- a/packages/app/src/baltici/components/SettleUpModal.tsx
+++ b/packages/app/src/baltici/components/SettleUpModal.tsx
@@ -1,6 +1,7 @@
-// Baltici — "I've settled up" modal. Open to everyone (no secret word): pick one
-// of the current who-owes lines (pairs with a pending claim are already filtered
-// out by the caller), say how it was settled, submit → a PENDING payment.
+// Baltici — "I've settled up" modal, opened from a who-owes row. The debt is
+// already chosen (pair + amount frozen at click time by the caller); the modal
+// only asks how it was settled, then creates the PENDING claim. Open to
+// everyone — the secret word gates the confirmation, not the claim.
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,35 +15,29 @@ const mono = "'Space Mono', monospace";
 
 export function SettleUpModal({
   people,
-  available,
+  line,
   onSubmit,
   onClose,
 }: {
   people: Person[];
-  /** who-owes lines still claimable (no pending payment for the pair) */
-  available: Settlement[];
+  /** the who-owes line being claimed (frozen snapshot) */
+  line: Settlement;
   /** returns true when the claim was recorded */
   onSubmit: (draft: PaymentDraft) => boolean;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
-  const [picked, setPicked] = useState<number | null>(null);
   const [method, setMethod] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const byId = (id: string): Person | undefined =>
-    people.find((p) => p.id === id);
+  const from = people.find((p) => p.id === line.fromId);
+  const to = people.find((p) => p.id === line.toId);
 
   const submit = () => {
-    if (picked === null || !available[picked]) {
-      setError(t("baltici.settle.errPick"));
-      return;
-    }
     if (method.trim() === "") {
       setError(t("baltici.settle.errMethod"));
       return;
     }
-    const line = available[picked];
     const ok = onSubmit({
       fromId: line.fromId,
       toId: line.toId,
@@ -85,8 +80,6 @@ export function SettleUpModal({
           padding: 20,
           width: "100%",
           maxWidth: 460,
-          maxHeight: "85vh",
-          overflowY: "auto",
           boxSizing: "border-box",
         }}
       >
@@ -94,52 +87,22 @@ export function SettleUpModal({
           {t("baltici.settle.modalTitle")}
         </h3>
 
-        <div style={{ font: `700 11px/1 ${mono}`, letterSpacing: ".1em", textTransform: "uppercase", opacity: 0.75, marginBottom: 6 }}>
-          {t("baltici.settle.pickDebt")}
-        </div>
-
-        {available.length === 0 && (
-          <p style={{ font: `400 13px/1.5 ${mono}`, opacity: 0.75 }}>
-            {t("baltici.settle.noDebts")}
-          </p>
-        )}
-
-        <div style={{ display: "grid", gap: 6 }}>
-          {available.map((line, i) => {
-            const from = byId(line.fromId);
-            const to = byId(line.toId);
-            if (!from || !to) return null;
-            const on = picked === i;
-            return (
-              <button
-                key={`${line.fromId}-${line.toId}`}
-                type="button"
-                onClick={() => {
-                  setPicked(i);
-                  setError(null);
-                }}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  font: `${on ? 700 : 400} 13px/1 ${mono}`,
-                  padding: "9px 10px",
-                  border: "1.5px solid currentColor",
-                  background: on ? PAPER : "transparent",
-                  color: on ? INK : "inherit",
-                  cursor: "pointer",
-                  textAlign: "left",
-                }}
-              >
-                <PersonAvatar person={from} size={22} />
-                <span>{from.name}</span>
-                <span style={{ opacity: 0.6 }}>→</span>
-                <PersonAvatar person={to} size={22} />
-                <span style={{ flex: 1 }}>{to.name}</span>
-                <span style={{ fontWeight: 700 }}>{formatEuro(line.amountCents)}</span>
-              </button>
-            );
-          })}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            font: `400 13px/1 ${mono}`,
+            padding: "9px 10px",
+            border: "1.5px solid currentColor",
+          }}
+        >
+          {from && <PersonAvatar person={from} size={22} />}
+          <span>{from?.name ?? "?"}</span>
+          <span style={{ opacity: 0.6 }}>→</span>
+          {to && <PersonAvatar person={to} size={22} />}
+          <span style={{ flex: 1 }}>{to?.name ?? "?"}</span>
+          <span style={{ fontWeight: 700 }}>{formatEuro(line.amountCents)}</span>
         </div>
 
         <div style={{ marginTop: 14 }}>
@@ -147,6 +110,7 @@ export function SettleUpModal({
             {t("baltici.settle.method")}
           </div>
           <input
+            autoFocus
             value={method}
             placeholder={t("baltici.settle.methodPlaceholder")}
             onChange={(e) => {
@@ -178,15 +142,13 @@ export function SettleUpModal({
           <button
             type="button"
             onClick={submit}
-            disabled={available.length === 0}
             style={{
               font: `700 13px/1 ${mono}`,
               border: `1.5px solid ${PAPER}`,
               background: PAPER,
               color: INK,
               padding: "11px 16px",
-              cursor: available.length === 0 ? "not-allowed" : "pointer",
-              opacity: available.length === 0 ? 0.5 : 1,
+              cursor: "pointer",
             }}
           >
             {t("baltici.settle.submit")}

--- a/packages/app/src/baltici/components/SettleUpModal.tsx
+++ b/packages/app/src/baltici/components/SettleUpModal.tsx
@@ -1,0 +1,212 @@
+// Baltici — "I've settled up" modal. Open to everyone (no secret word): pick one
+// of the current who-owes lines (pairs with a pending claim are already filtered
+// out by the caller), say how it was settled, submit → a PENDING payment.
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Person } from "../model";
+import type { Settlement } from "../calc";
+import type { PaymentDraft } from "../validation";
+import { formatEuro } from "../money";
+import { PersonAvatar, PAPER, INK } from "./atoms";
+
+const mono = "'Space Mono', monospace";
+
+export function SettleUpModal({
+  people,
+  available,
+  onSubmit,
+  onClose,
+}: {
+  people: Person[];
+  /** who-owes lines still claimable (no pending payment for the pair) */
+  available: Settlement[];
+  /** returns true when the claim was recorded */
+  onSubmit: (draft: PaymentDraft) => boolean;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const [picked, setPicked] = useState<number | null>(null);
+  const [method, setMethod] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const byId = (id: string): Person | undefined =>
+    people.find((p) => p.id === id);
+
+  const submit = () => {
+    if (picked === null || !available[picked]) {
+      setError(t("baltici.settle.errPick"));
+      return;
+    }
+    if (method.trim() === "") {
+      setError(t("baltici.settle.errMethod"));
+      return;
+    }
+    const line = available[picked];
+    const ok = onSubmit({
+      fromId: line.fromId,
+      toId: line.toId,
+      amountCents: line.amountCents,
+      method,
+    });
+    if (!ok) {
+      setError(t("baltici.settle.errGeneric"));
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,.65)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        zIndex: 100,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("baltici.settle.modalTitle")}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: INK,
+          color: PAPER,
+          border: `1.5px solid ${PAPER}`,
+          padding: 20,
+          width: "100%",
+          maxWidth: 460,
+          maxHeight: "85vh",
+          overflowY: "auto",
+          boxSizing: "border-box",
+        }}
+      >
+        <h3 style={{ font: `700 13px/1 ${mono}`, letterSpacing: ".14em", textTransform: "uppercase", margin: "0 0 14px" }}>
+          {t("baltici.settle.modalTitle")}
+        </h3>
+
+        <div style={{ font: `700 11px/1 ${mono}`, letterSpacing: ".1em", textTransform: "uppercase", opacity: 0.75, marginBottom: 6 }}>
+          {t("baltici.settle.pickDebt")}
+        </div>
+
+        {available.length === 0 && (
+          <p style={{ font: `400 13px/1.5 ${mono}`, opacity: 0.75 }}>
+            {t("baltici.settle.noDebts")}
+          </p>
+        )}
+
+        <div style={{ display: "grid", gap: 6 }}>
+          {available.map((line, i) => {
+            const from = byId(line.fromId);
+            const to = byId(line.toId);
+            if (!from || !to) return null;
+            const on = picked === i;
+            return (
+              <button
+                key={`${line.fromId}-${line.toId}`}
+                type="button"
+                onClick={() => {
+                  setPicked(i);
+                  setError(null);
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  font: `${on ? 700 : 400} 13px/1 ${mono}`,
+                  padding: "9px 10px",
+                  border: "1.5px solid currentColor",
+                  background: on ? PAPER : "transparent",
+                  color: on ? INK : "inherit",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                <PersonAvatar person={from} size={22} />
+                <span>{from.name}</span>
+                <span style={{ opacity: 0.6 }}>→</span>
+                <PersonAvatar person={to} size={22} />
+                <span style={{ flex: 1 }}>{to.name}</span>
+                <span style={{ fontWeight: 700 }}>{formatEuro(line.amountCents)}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{ marginTop: 14 }}>
+          <div style={{ font: `700 11px/1 ${mono}`, letterSpacing: ".1em", textTransform: "uppercase", opacity: 0.75, marginBottom: 6 }}>
+            {t("baltici.settle.method")}
+          </div>
+          <input
+            value={method}
+            placeholder={t("baltici.settle.methodPlaceholder")}
+            onChange={(e) => {
+              setMethod(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            style={{
+              font: `400 14px/1 ${mono}`,
+              padding: "9px 10px",
+              border: "1.5px solid currentColor",
+              background: "transparent",
+              color: "inherit",
+              width: "100%",
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {error && (
+          <div style={{ font: `700 12px/1.4 ${mono}`, color: "#e08b8b", marginTop: 10 }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={available.length === 0}
+            style={{
+              font: `700 13px/1 ${mono}`,
+              border: `1.5px solid ${PAPER}`,
+              background: PAPER,
+              color: INK,
+              padding: "11px 16px",
+              cursor: available.length === 0 ? "not-allowed" : "pointer",
+              opacity: available.length === 0 ? 0.5 : 1,
+            }}
+          >
+            {t("baltici.settle.submit")}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              font: `400 13px/1 ${mono}`,
+              border: "1.5px solid currentColor",
+              background: "transparent",
+              color: "inherit",
+              padding: "11px 16px",
+              cursor: "pointer",
+            }}
+          >
+            {t("baltici.settle.cancel")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/baltici/db.ts
+++ b/packages/app/src/baltici/db.ts
@@ -28,6 +28,15 @@ export const schema = i.schema({
       createdAt: i.number(),
       deleted: i.boolean(), // soft-delete
     }),
+    payments: i.entity({
+      fromId: i.string(), // debtor
+      toId: i.string(), // creditor
+      amountCents: i.number(), // frozen at claim time
+      method: i.string(), // free text: PayPal, cash, …
+      status: i.string(), // "pending" | "confirmed" (rejected claims are soft-deleted)
+      createdAt: i.number(),
+      deleted: i.boolean(), // soft-delete
+    }),
     meta: i.entity({
       groupName: i.string(),
     }),

--- a/packages/app/src/baltici/model.ts
+++ b/packages/app/src/baltici/model.ts
@@ -38,10 +38,36 @@ export interface ExactExpense extends ExpenseBase {
 
 export type Expense = EqualExpense | ExactExpense;
 
+export type PaymentStatus = "pending" | "confirmed";
+
+/**
+ * A settle-up claim, in two phases. Anyone can create one ("I've settled up"):
+ * it freezes a who-owes line (from → to, amount snapshot at click time) plus a
+ * free-text method (PayPal, cash, …). It only affects balances once CONFIRMED
+ * with the secret word; a rejected claim is soft-deleted without a trace.
+ * A confirmed payment acts as a money transfer from → to (it is NOT an expense:
+ * the trip total ignores it).
+ */
+export interface Payment {
+  id: string;
+  fromId: PersonId; // debtor (who claims they paid)
+  toId: PersonId; // creditor (who received the money)
+  amountCents: number; // frozen at claim time, > 0
+  method: string; // how it was settled (free text)
+  status: PaymentStatus;
+  createdAt: number;
+}
+
+/** Everyone referenced by a payment. Blocks removing a person involved in one. */
+export function personIdsInPayment(p: Payment): PersonId[] {
+  return [p.fromId, p.toId];
+}
+
 export interface GroupState {
   name: string;
   people: Person[]; // canonical order (by createdAt) — see calc.shareOf
   expenses: Expense[];
+  payments: Payment[];
 }
 
 /** The people who share an expense — the single source of truth per split mode. */

--- a/packages/app/src/baltici/store.ts
+++ b/packages/app/src/baltici/store.ts
@@ -9,15 +9,20 @@ import { balances, simplifyDebts, totals, type Settlement } from "./calc";
 import {
   type Expense,
   type GroupState,
+  type Payment,
   type Person,
   type PersonId,
   personIdsInExpense,
+  personIdsInPayment,
 } from "./model";
 import { pickColor } from "./colors";
 import {
   validateExpense,
+  validatePayment,
   type ExpenseDraft,
   type ExpenseValidationError,
+  type PaymentDraft,
+  type PaymentValidationError,
 } from "./validation";
 
 interface RawRow {
@@ -63,11 +68,33 @@ function mapExpense(r: RawRow): Expense | null {
   return { ...base, splitMode: "equal", participants };
 }
 
+function mapPayment(r: RawRow): Payment | null {
+  const idv = r.id;
+  const fromId = r.fromId;
+  const toId = r.toId;
+  if (
+    typeof idv !== "string" ||
+    typeof fromId !== "string" ||
+    typeof toId !== "string"
+  )
+    return null;
+  return {
+    id: idv,
+    fromId,
+    toId,
+    amountCents: num(r.amountCents),
+    method: str(r.method),
+    status: r.status === "confirmed" ? "confirmed" : "pending",
+    createdAt: num(r.createdAt),
+  };
+}
+
 /** Pure mapper: InstantDB query result → GroupState. People ordered by
  *  createdAt (canonical), soft-deleted rows filtered out. */
 export function toGroupState(data: {
   people?: RawRow[];
   expenses?: RawRow[];
+  payments?: RawRow[];
   meta?: RawRow[];
 }): GroupState {
   const people: Person[] = (data.people ?? [])
@@ -86,19 +113,26 @@ export function toGroupState(data: {
     .filter((e): e is Expense => e !== null)
     .sort((a, b) => b.createdAt - a.createdAt); // newest first (list view)
 
+  const payments: Payment[] = (data.payments ?? [])
+    .filter((r) => r.deleted !== true)
+    .map(mapPayment)
+    .filter((p): p is Payment => p !== null)
+    .sort((a, b) => b.createdAt - a.createdAt); // newest first (list view)
+
   // Singleton group row lives at META_ID; fall back to the first row for any
   // legacy/leftover meta row so the name is read deterministically.
   const metaRows = data.meta ?? [];
   const metaRow = metaRows.find((r) => r.id === META_ID) ?? metaRows[0];
   const name = str(metaRow?.groupName);
-  return { name, people, expenses };
+  return { name, people, expenses, payments };
 }
 
 export interface BalticiActions {
   setGroupName(name: string): void;
   addPerson(name: string): void;
   renamePerson(personId: PersonId, name: string): void;
-  /** Returns false (and does nothing) if the person is referenced by any expense. */
+  /** Returns false (and does nothing) if the person is referenced by any
+   *  expense or payment. */
   removePerson(personId: PersonId): boolean;
   canRemovePerson(personId: PersonId): boolean;
   addExpense(draft: ExpenseDraft): ExpenseValidationError | null;
@@ -107,6 +141,12 @@ export interface BalticiActions {
     draft: ExpenseDraft
   ): ExpenseValidationError | null;
   removeExpense(expenseId: string): void;
+  /** "I've settled up" claim: freezes a who-owes line as a PENDING payment. */
+  addPayment(draft: PaymentDraft): PaymentValidationError | null;
+  /** Secret-word decision on a pending claim: archive it (affects balances)… */
+  confirmPayment(paymentId: string): void;
+  /** …or drop it without a trace (the debt reappears intact). */
+  rejectPayment(paymentId: string): void;
 }
 
 export interface UseBalticiResult {
@@ -126,6 +166,7 @@ export function useBaltici(): UseBalticiResult {
   const { isLoading, error, data } = database.useQuery({
     people: {},
     expenses: {},
+    payments: {},
     meta: {},
   });
 
@@ -202,14 +243,23 @@ export function useBaltici(): UseBalticiResult {
         );
       },
       canRemovePerson(personId) {
-        return !state.expenses.some((e) =>
-          personIdsInExpense(e).includes(personId)
+        return (
+          !state.expenses.some((e) =>
+            personIdsInExpense(e).includes(personId)
+          ) &&
+          !state.payments.some((p) =>
+            personIdsInPayment(p).includes(personId)
+          )
         );
       },
       removePerson(personId) {
-        const referenced = state.expenses.some((e) =>
-          personIdsInExpense(e).includes(personId)
-        );
+        const referenced =
+          state.expenses.some((e) =>
+            personIdsInExpense(e).includes(personId)
+          ) ||
+          state.payments.some((p) =>
+            personIdsInPayment(p).includes(personId)
+          );
         if (referenced) return false;
         database.transact(
           database.tx.people[personId].update({ deleted: true })
@@ -225,6 +275,37 @@ export function useBaltici(): UseBalticiResult {
       removeExpense(expenseId) {
         database.transact(
           database.tx.expenses[expenseId].update({ deleted: true })
+        );
+      },
+      addPayment(draft) {
+        const err = validatePayment(draft, peopleIds(), state.payments);
+        if (err) return err;
+        database.transact(
+          database.tx.payments[id()].update({
+            fromId: draft.fromId,
+            toId: draft.toId,
+            amountCents: draft.amountCents,
+            method: draft.method.trim(),
+            status: "pending",
+            createdAt: nowStamp(state),
+            deleted: false,
+          })
+        );
+        return null;
+      },
+      confirmPayment(paymentId) {
+        // Only a live pending claim can be archived (guards a stale click).
+        const p = state.payments.find((x) => x.id === paymentId);
+        if (!p || p.status !== "pending") return;
+        database.transact(
+          database.tx.payments[paymentId].update({ status: "confirmed" })
+        );
+      },
+      rejectPayment(paymentId) {
+        const p = state.payments.find((x) => x.id === paymentId);
+        if (!p || p.status !== "pending") return;
+        database.transact(
+          database.tx.payments[paymentId].update({ deleted: true })
         );
       },
     };
@@ -248,6 +329,7 @@ function nowStamp(state: GroupState): number {
   const stamps = [
     ...state.people.map((p) => p.createdAt),
     ...state.expenses.map((e) => e.createdAt),
+    ...state.payments.map((p) => p.createdAt),
     Date.now(),
   ];
   return Math.max(...stamps) + 1;

--- a/packages/app/src/baltici/validation.ts
+++ b/packages/app/src/baltici/validation.ts
@@ -84,7 +84,10 @@ export type PaymentValidationError =
   | "duplicate-pending";
 
 /** Returns null when valid, otherwise the first error found. `payments` are the
- *  live (non-deleted) ones — only one PENDING claim per from→to pair may exist. */
+ *  live (non-deleted) ones — only one PENDING claim per from→to pair may exist.
+ *  NOTE: the duplicate-pending guard is client-side (no server): two devices
+ *  claiming the same pair simultaneously can both pass. Realtime sync keeps the
+ *  window tiny, and the confirmer simply rejects the extra claim. */
 export function validatePayment(
   draft: PaymentDraft,
   peopleIds: ReadonlySet<PersonId>,

--- a/packages/app/src/baltici/validation.ts
+++ b/packages/app/src/baltici/validation.ts
@@ -1,8 +1,8 @@
-// Baltici — expense validation. Pure; reused by the store (guard before writing)
-// and by unit tests. Prevents illegal states (e.g. equal split with no
+// Baltici — expense/payment validation. Pure; reused by the store (guard before
+// writing) and by unit tests. Prevents illegal states (e.g. equal split with no
 // participants → shareOf would divide by zero; exact shares not summing to total).
 
-import { type PersonId } from "./model";
+import { type Payment, type PersonId } from "./model";
 
 export interface EqualDraft {
   splitMode: "equal";
@@ -67,5 +67,44 @@ export function validateExpense(
     sum += share;
   }
   if (sum !== draft.amountCents) return "shares-mismatch";
+  return null;
+}
+
+export interface PaymentDraft {
+  fromId: PersonId; // debtor
+  toId: PersonId; // creditor
+  amountCents: number;
+  method: string;
+}
+
+export type PaymentValidationError =
+  | "bad-people"
+  | "bad-amount"
+  | "no-method"
+  | "duplicate-pending";
+
+/** Returns null when valid, otherwise the first error found. `payments` are the
+ *  live (non-deleted) ones — only one PENDING claim per from→to pair may exist. */
+export function validatePayment(
+  draft: PaymentDraft,
+  peopleIds: ReadonlySet<PersonId>,
+  payments: readonly Payment[]
+): PaymentValidationError | null {
+  if (
+    !peopleIds.has(draft.fromId) ||
+    !peopleIds.has(draft.toId) ||
+    draft.fromId === draft.toId
+  )
+    return "bad-people";
+  if (!Number.isInteger(draft.amountCents) || draft.amountCents <= 0)
+    return "bad-amount";
+  if (draft.method.trim() === "") return "no-method";
+  const dup = payments.some(
+    (p) =>
+      p.status === "pending" &&
+      p.fromId === draft.fromId &&
+      p.toId === draft.toId
+  );
+  if (dup) return "duplicate-pending";
   return null;
 }

--- a/packages/app/src/layouts/BalticiLayout.tsx
+++ b/packages/app/src/layouts/BalticiLayout.tsx
@@ -33,6 +33,7 @@ function BalticiLayout() {
             [t("baltici.tabs.home"), "/secret-baltici"],
             [t("baltici.tabs.expenses"), "/secret-baltici/expenses"],
             [t("baltici.tabs.whoOwes"), "/secret-baltici/who-owes"],
+            [t("baltici.tabs.settled"), "/secret-baltici/settled"],
             [t("baltici.tabs.people"), "/secret-baltici/people"],
           ]}
         />

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -91,6 +91,7 @@
         "home": "SUMMARY",
         "expenses": "EXPENSES",
         "whoOwes": "WHO OWES",
+        "settled": "SETTLED DEBTS",
         "people": "PEOPLE"
       },
       "notConfigured": {
@@ -170,13 +171,14 @@
       "settle": {
         "button": "✓ I'VE SETTLED UP",
         "modalTitle": "I've settled up",
-        "pickDebt": "Which debt did you settle?",
-        "noDebts": "Nothing to settle right now — either all even, or already waiting for confirmation.",
+        "listTitle": "Settled debts",
+        "emptyList": "No settle-ups yet. Claim one with the button on a Who owes row.",
+        "pendingSection": "Waiting for confirmation",
+        "settledSection": "Settled",
         "method": "How did you settle?",
         "methodPlaceholder": "e.g. PayPal, bank transfer, cash",
         "submit": "MARK AS SETTLED",
         "cancel": "CANCEL",
-        "errPick": "Pick the debt you settled.",
         "errMethod": "Say how you settled it.",
         "errGeneric": "Couldn't record this settle-up. Reload and try again.",
         "via": "settled via {{method}}",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -166,6 +166,24 @@
         "wordPlaceholder": "Secret word",
         "unlock": "UNLOCK",
         "wrong": "Wrong word."
+      },
+      "settle": {
+        "button": "✓ I'VE SETTLED UP",
+        "modalTitle": "I've settled up",
+        "pickDebt": "Which debt did you settle?",
+        "noDebts": "Nothing to settle right now — either all even, or already waiting for confirmation.",
+        "method": "How did you settle?",
+        "methodPlaceholder": "e.g. PayPal, bank transfer, cash",
+        "submit": "MARK AS SETTLED",
+        "cancel": "CANCEL",
+        "errPick": "Pick the debt you settled.",
+        "errMethod": "Say how you settled it.",
+        "errGeneric": "Couldn't record this settle-up. Reload and try again.",
+        "via": "settled via {{method}}",
+        "pending": "WAITING FOR CONFIRMATION",
+        "settled": "SETTLED",
+        "confirm": "OK, SETTLED",
+        "reject": "NOT SETTLED"
       }
     }
   }

--- a/packages/app/src/pages/baltici/BalticiExpenses.tsx
+++ b/packages/app/src/pages/baltici/BalticiExpenses.tsx
@@ -1,13 +1,11 @@
-import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
 import { useEditGate } from "../../baltici/editGate";
 import { UnlockBar } from "../../baltici/editGateUI";
-import { Row, EmptyState, SectionTitle, PAPER, INK } from "../../baltici/components/atoms";
-import { SettleUpModal } from "../../baltici/components/SettleUpModal";
+import { Row, EmptyState, SectionTitle } from "../../baltici/components/atoms";
 import { formatEuro } from "../../baltici/money";
-import { participantsOf, type Expense, type Payment, type Person } from "../../baltici/model";
+import { participantsOf, type Expense, type Person } from "../../baltici/model";
 
 const mono = "'Space Mono', monospace";
 
@@ -18,183 +16,63 @@ function splitSummary(e: Expense, people: Person[], allLabel: string): string {
   return `${parts.length}`;
 }
 
-// Expenses and settle-up payments share one chronological list.
-type ListItem =
-  | { kind: "expense"; createdAt: number; expense: Expense }
-  | { kind: "payment"; createdAt: number; payment: Payment };
-
 function BalticiExpenses() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { state, settlements, actions } = useBaltici();
+  const { state, actions } = useBaltici();
   const gate = useEditGate();
-  const [settleOpen, setSettleOpen] = useState(false);
 
   const nameOf = (id: string) => state.people.find((p) => p.id === id)?.name ?? "?";
-
-  // who-owes lines still claimable: only one pending claim per from→to pair.
-  const claimable = settlements.filter(
-    (s) =>
-      !state.payments.some(
-        (p) => p.status === "pending" && p.fromId === s.fromId && p.toId === s.toId
-      )
-  );
-
-  const items: ListItem[] = [
-    ...state.expenses.map<ListItem>((e) => ({ kind: "expense", createdAt: e.createdAt, expense: e })),
-    ...state.payments.map<ListItem>((p) => ({ kind: "payment", createdAt: p.createdAt, payment: p })),
-  ].sort((a, b) => b.createdAt - a.createdAt);
 
   return (
     <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
         <SectionTitle>{t("baltici.expenses.title")}</SectionTitle>
-        <div style={{ display: "flex", gap: 8 }}>
-          <button
-            type="button"
-            onClick={() => setSettleOpen(true)}
-            style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "9px 12px", cursor: "pointer" }}
-          >
-            {t("baltici.settle.button")}
-          </button>
-          <Link
-            to="/secret-baltici/expenses/new"
-            style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
-          >
-            {t("baltici.expenses.add")}
-          </Link>
-        </div>
+        <Link
+          to="/secret-baltici/expenses/new"
+          style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
+        >
+          {t("baltici.expenses.add")}
+        </Link>
       </div>
 
       <UnlockBar />
 
-      {items.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
+      {state.expenses.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
 
-      {items.map((item) =>
-        item.kind === "expense" ? (
-          <ExpenseRow
-            key={item.expense.id}
-            e={item.expense}
-            people={state.people}
-            nameOf={nameOf}
-            canEdit={gate.canEdit}
-            onEdit={() => navigate(`/secret-baltici/expenses/${item.expense.id}/edit`)}
-            onRemove={() => actions.removeExpense(item.expense.id)}
-          />
-        ) : (
-          <PaymentRow
-            key={item.payment.id}
-            p={item.payment}
-            nameOf={nameOf}
-            canDecide={gate.canEdit}
-            onConfirm={() => actions.confirmPayment(item.payment.id)}
-            onReject={() => actions.rejectPayment(item.payment.id)}
-          />
-        )
-      )}
-
-      {settleOpen && (
-        <SettleUpModal
-          people={state.people}
-          available={claimable}
-          onSubmit={(draft) => actions.addPayment(draft) === null}
-          onClose={() => setSettleOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-function ExpenseRow({
-  e,
-  people,
-  nameOf,
-  canEdit,
-  onEdit,
-  onRemove,
-}: {
-  e: Expense;
-  people: Person[];
-  nameOf: (id: string) => string;
-  canEdit: boolean;
-  onEdit: () => void;
-  onRemove: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <Row style={{ alignItems: "flex-start" }}>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ font: `700 14px/1.2 ${mono}` }}>{e.description}</div>
-        <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
-          {t("baltici.expenses.paidBy", { name: nameOf(e.payerId) })} · {e.date} ·{" "}
-          {splitSummary(e, people, t("baltici.expenses.all"))}
-        </div>
-      </div>
-      <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
-      {canEdit && (
-        <div style={{ display: "flex", gap: 6 }}>
-          <button type="button" onClick={onEdit} style={btnStyle} aria-label={t("baltici.expenses.edit")}>
-            {t("baltici.expenses.edit")}
-          </button>
-          <button type="button" onClick={onRemove} style={btnStyle} aria-label={t("baltici.expenses.remove")}>
-            {t("baltici.expenses.remove")}
-          </button>
-        </div>
-      )}
-    </Row>
-  );
-}
-
-/** A settle-up claim row. Pending: locked, waiting for the secret-word decision
- *  (the two buttons only show once unlocked). Confirmed: archived, grayed out. */
-function PaymentRow({
-  p,
-  nameOf,
-  canDecide,
-  onConfirm,
-  onReject,
-}: {
-  p: Payment;
-  nameOf: (id: string) => string;
-  canDecide: boolean;
-  onConfirm: () => void;
-  onReject: () => void;
-}) {
-  const { t } = useTranslation();
-  const confirmed = p.status === "confirmed";
-  return (
-    <Row style={{ alignItems: "flex-start", opacity: confirmed ? 0.45 : 1 }}>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ font: `700 14px/1.2 ${mono}` }}>
-          {nameOf(p.fromId)} → {nameOf(p.toId)}
-        </div>
-        <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
-          {t("baltici.settle.via", { method: p.method })}
-        </div>
-      </div>
-      <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(p.amountCents)}</div>
-      {confirmed ? (
-        <span style={badgeStyle}>{t("baltici.settle.settled")}</span>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
-          <span style={badgeStyle}>🔒 {t("baltici.settle.pending")}</span>
-          {canDecide && (
+      {state.expenses.map((e) => (
+        <Row key={e.id} style={{ alignItems: "flex-start" }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ font: `700 14px/1.2 ${mono}` }}>{e.description}</div>
+            <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
+              {t("baltici.expenses.paidBy", { name: nameOf(e.payerId) })} · {e.date} ·{" "}
+              {splitSummary(e, state.people, t("baltici.expenses.all"))}
+            </div>
+          </div>
+          <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
+          {gate.canEdit && (
             <div style={{ display: "flex", gap: 6 }}>
               <button
                 type="button"
-                onClick={onConfirm}
-                style={{ ...btnStyle, border: `1.5px solid ${PAPER}`, background: PAPER, color: INK }}
+                onClick={() => navigate(`/secret-baltici/expenses/${e.id}/edit`)}
+                style={btnStyle}
+                aria-label={t("baltici.expenses.edit")}
               >
-                {t("baltici.settle.confirm")}
+                {t("baltici.expenses.edit")}
               </button>
-              <button type="button" onClick={onReject} style={btnStyle}>
-                {t("baltici.settle.reject")}
+              <button
+                type="button"
+                onClick={() => actions.removeExpense(e.id)}
+                style={btnStyle}
+                aria-label={t("baltici.expenses.remove")}
+              >
+                {t("baltici.expenses.remove")}
               </button>
             </div>
           )}
-        </div>
-      )}
-    </Row>
+        </Row>
+      ))}
+    </div>
   );
 }
 
@@ -205,14 +83,6 @@ const btnStyle = {
   color: "inherit",
   padding: "6px 8px",
   cursor: "pointer",
-} as const;
-
-const badgeStyle = {
-  font: `700 10px/1 ${mono}`,
-  letterSpacing: ".08em",
-  border: "1px solid currentColor",
-  padding: "5px 7px",
-  whiteSpace: "nowrap",
 } as const;
 
 export default BalticiExpenses;

--- a/packages/app/src/pages/baltici/BalticiExpenses.tsx
+++ b/packages/app/src/pages/baltici/BalticiExpenses.tsx
@@ -1,11 +1,13 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
 import { useEditGate } from "../../baltici/editGate";
 import { UnlockBar } from "../../baltici/editGateUI";
-import { Row, EmptyState, SectionTitle } from "../../baltici/components/atoms";
+import { Row, EmptyState, SectionTitle, PAPER, INK } from "../../baltici/components/atoms";
+import { SettleUpModal } from "../../baltici/components/SettleUpModal";
 import { formatEuro } from "../../baltici/money";
-import { participantsOf, type Expense, type Person } from "../../baltici/model";
+import { participantsOf, type Expense, type Payment, type Person } from "../../baltici/model";
 
 const mono = "'Space Mono', monospace";
 
@@ -16,63 +18,183 @@ function splitSummary(e: Expense, people: Person[], allLabel: string): string {
   return `${parts.length}`;
 }
 
+// Expenses and settle-up payments share one chronological list.
+type ListItem =
+  | { kind: "expense"; createdAt: number; expense: Expense }
+  | { kind: "payment"; createdAt: number; payment: Payment };
+
 function BalticiExpenses() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { state, actions } = useBaltici();
+  const { state, settlements, actions } = useBaltici();
   const gate = useEditGate();
+  const [settleOpen, setSettleOpen] = useState(false);
 
   const nameOf = (id: string) => state.people.find((p) => p.id === id)?.name ?? "?";
 
+  // who-owes lines still claimable: only one pending claim per from→to pair.
+  const claimable = settlements.filter(
+    (s) =>
+      !state.payments.some(
+        (p) => p.status === "pending" && p.fromId === s.fromId && p.toId === s.toId
+      )
+  );
+
+  const items: ListItem[] = [
+    ...state.expenses.map<ListItem>((e) => ({ kind: "expense", createdAt: e.createdAt, expense: e })),
+    ...state.payments.map<ListItem>((p) => ({ kind: "payment", createdAt: p.createdAt, payment: p })),
+  ].sort((a, b) => b.createdAt - a.createdAt);
+
   return (
     <div>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
         <SectionTitle>{t("baltici.expenses.title")}</SectionTitle>
-        <Link
-          to="/secret-baltici/expenses/new"
-          style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
-        >
-          {t("baltici.expenses.add")}
-        </Link>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => setSettleOpen(true)}
+            style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "9px 12px", cursor: "pointer" }}
+          >
+            {t("baltici.settle.button")}
+          </button>
+          <Link
+            to="/secret-baltici/expenses/new"
+            style={{ font: `700 12px/1 ${mono}`, border: "1.5px solid currentColor", padding: "9px 12px", textDecoration: "none", color: "inherit" }}
+          >
+            {t("baltici.expenses.add")}
+          </Link>
+        </div>
       </div>
 
       <UnlockBar />
 
-      {state.expenses.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
+      {items.length === 0 && <EmptyState>{t("baltici.expenses.empty")}</EmptyState>}
 
-      {state.expenses.map((e) => (
-        <Row key={e.id} style={{ alignItems: "flex-start" }}>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ font: `700 14px/1.2 ${mono}` }}>{e.description}</div>
-            <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
-              {t("baltici.expenses.paidBy", { name: nameOf(e.payerId) })} · {e.date} ·{" "}
-              {splitSummary(e, state.people, t("baltici.expenses.all"))}
-            </div>
-          </div>
-          <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
-          {gate.canEdit && (
+      {items.map((item) =>
+        item.kind === "expense" ? (
+          <ExpenseRow
+            key={item.expense.id}
+            e={item.expense}
+            people={state.people}
+            nameOf={nameOf}
+            canEdit={gate.canEdit}
+            onEdit={() => navigate(`/secret-baltici/expenses/${item.expense.id}/edit`)}
+            onRemove={() => actions.removeExpense(item.expense.id)}
+          />
+        ) : (
+          <PaymentRow
+            key={item.payment.id}
+            p={item.payment}
+            nameOf={nameOf}
+            canDecide={gate.canEdit}
+            onConfirm={() => actions.confirmPayment(item.payment.id)}
+            onReject={() => actions.rejectPayment(item.payment.id)}
+          />
+        )
+      )}
+
+      {settleOpen && (
+        <SettleUpModal
+          people={state.people}
+          available={claimable}
+          onSubmit={(draft) => actions.addPayment(draft) === null}
+          onClose={() => setSettleOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ExpenseRow({
+  e,
+  people,
+  nameOf,
+  canEdit,
+  onEdit,
+  onRemove,
+}: {
+  e: Expense;
+  people: Person[];
+  nameOf: (id: string) => string;
+  canEdit: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Row style={{ alignItems: "flex-start" }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ font: `700 14px/1.2 ${mono}` }}>{e.description}</div>
+        <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
+          {t("baltici.expenses.paidBy", { name: nameOf(e.payerId) })} · {e.date} ·{" "}
+          {splitSummary(e, people, t("baltici.expenses.all"))}
+        </div>
+      </div>
+      <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(e.amountCents)}</div>
+      {canEdit && (
+        <div style={{ display: "flex", gap: 6 }}>
+          <button type="button" onClick={onEdit} style={btnStyle} aria-label={t("baltici.expenses.edit")}>
+            {t("baltici.expenses.edit")}
+          </button>
+          <button type="button" onClick={onRemove} style={btnStyle} aria-label={t("baltici.expenses.remove")}>
+            {t("baltici.expenses.remove")}
+          </button>
+        </div>
+      )}
+    </Row>
+  );
+}
+
+/** A settle-up claim row. Pending: locked, waiting for the secret-word decision
+ *  (the two buttons only show once unlocked). Confirmed: archived, grayed out. */
+function PaymentRow({
+  p,
+  nameOf,
+  canDecide,
+  onConfirm,
+  onReject,
+}: {
+  p: Payment;
+  nameOf: (id: string) => string;
+  canDecide: boolean;
+  onConfirm: () => void;
+  onReject: () => void;
+}) {
+  const { t } = useTranslation();
+  const confirmed = p.status === "confirmed";
+  return (
+    <Row style={{ alignItems: "flex-start", opacity: confirmed ? 0.45 : 1 }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ font: `700 14px/1.2 ${mono}` }}>
+          {nameOf(p.fromId)} → {nameOf(p.toId)}
+        </div>
+        <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
+          {t("baltici.settle.via", { method: p.method })}
+        </div>
+      </div>
+      <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(p.amountCents)}</div>
+      {confirmed ? (
+        <span style={badgeStyle}>{t("baltici.settle.settled")}</span>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+          <span style={badgeStyle}>🔒 {t("baltici.settle.pending")}</span>
+          {canDecide && (
             <div style={{ display: "flex", gap: 6 }}>
               <button
                 type="button"
-                onClick={() => navigate(`/secret-baltici/expenses/${e.id}/edit`)}
-                style={btnStyle}
-                aria-label={t("baltici.expenses.edit")}
+                onClick={onConfirm}
+                style={{ ...btnStyle, border: `1.5px solid ${PAPER}`, background: PAPER, color: INK }}
               >
-                {t("baltici.expenses.edit")}
+                {t("baltici.settle.confirm")}
               </button>
-              <button
-                type="button"
-                onClick={() => actions.removeExpense(e.id)}
-                style={btnStyle}
-                aria-label={t("baltici.expenses.remove")}
-              >
-                {t("baltici.expenses.remove")}
+              <button type="button" onClick={onReject} style={btnStyle}>
+                {t("baltici.settle.reject")}
               </button>
             </div>
           )}
-        </Row>
-      ))}
-    </div>
+        </div>
+      )}
+    </Row>
   );
 }
 
@@ -83,6 +205,14 @@ const btnStyle = {
   color: "inherit",
   padding: "6px 8px",
   cursor: "pointer",
+} as const;
+
+const badgeStyle = {
+  font: `700 10px/1 ${mono}`,
+  letterSpacing: ".08em",
+  border: "1px solid currentColor",
+  padding: "5px 7px",
+  whiteSpace: "nowrap",
 } as const;
 
 export default BalticiExpenses;

--- a/packages/app/src/pages/baltici/BalticiSettleUp.tsx
+++ b/packages/app/src/pages/baltici/BalticiSettleUp.tsx
@@ -1,14 +1,20 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useBaltici } from "../../baltici/store";
 import { Row, EmptyState, SectionTitle, PersonAvatar } from "../../baltici/components/atoms";
+import { SettleUpModal } from "../../baltici/components/SettleUpModal";
 import { formatEuro } from "../../baltici/money";
 import type { Person } from "../../baltici/model";
+import type { Settlement } from "../../baltici/calc";
 
 const mono = "'Space Mono', monospace";
 
 function BalticiSettleUp() {
   const { t } = useTranslation();
-  const { state, settlements } = useBaltici();
+  const { state, settlements, actions } = useBaltici();
+  // The line being claimed — a snapshot taken at click time, so the amount is
+  // frozen even if expenses change while the modal is open.
+  const [claiming, setClaiming] = useState<Settlement | null>(null);
 
   const byId = (id: string): Person | undefined => state.people.find((p) => p.id === id);
 
@@ -26,23 +32,31 @@ function BalticiSettleUp() {
         const to = byId(s.toId);
         if (!from || !to) return null;
         // A claim is waiting for the secret-word decision on this pair — the
-        // debt stays counted (and shown) until it's confirmed.
+        // debt stays counted (and shown) until it's confirmed; no second claim.
         const pending = state.payments.some(
           (p) => p.status === "pending" && p.fromId === s.fromId && p.toId === s.toId
         );
         return (
-          <Row key={i}>
+          <Row key={i} style={{ flexWrap: "wrap" }}>
             <PersonAvatar person={from} size={26} />
             <span style={{ font: `400 14px/1 ${mono}` }}>{from.name}</span>
             <span style={{ opacity: 0.6 }}>→</span>
             <PersonAvatar person={to} size={26} />
             <span style={{ flex: 1, font: `400 14px/1 ${mono}` }}>{to.name}</span>
-            {pending && (
+            <span style={{ font: `700 14px/1 ${mono}` }}>{formatEuro(s.amountCents)}</span>
+            {pending ? (
               <span style={{ font: `700 10px/1 ${mono}`, letterSpacing: ".08em", border: "1px solid currentColor", padding: "5px 7px", opacity: 0.75, whiteSpace: "nowrap" }}>
                 🔒 {t("baltici.settle.pending")}
               </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setClaiming(s)}
+                style={{ font: `700 11px/1 ${mono}`, border: "1.5px solid currentColor", background: "transparent", color: "inherit", padding: "6px 8px", cursor: "pointer", whiteSpace: "nowrap" }}
+              >
+                {t("baltici.settle.button")}
+              </button>
             )}
-            <span style={{ font: `700 14px/1 ${mono}` }}>{formatEuro(s.amountCents)}</span>
           </Row>
         );
       })}
@@ -50,6 +64,15 @@ function BalticiSettleUp() {
       <p style={{ font: `400 12px/1.5 ${mono}`, opacity: 0.65, marginTop: 16 }}>
         {t("baltici.whoOwes.hint")}
       </p>
+
+      {claiming && (
+        <SettleUpModal
+          people={state.people}
+          line={claiming}
+          onSubmit={(draft) => actions.addPayment(draft) === null}
+          onClose={() => setClaiming(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/app/src/pages/baltici/BalticiSettleUp.tsx
+++ b/packages/app/src/pages/baltici/BalticiSettleUp.tsx
@@ -25,6 +25,11 @@ function BalticiSettleUp() {
         const from = byId(s.fromId);
         const to = byId(s.toId);
         if (!from || !to) return null;
+        // A claim is waiting for the secret-word decision on this pair — the
+        // debt stays counted (and shown) until it's confirmed.
+        const pending = state.payments.some(
+          (p) => p.status === "pending" && p.fromId === s.fromId && p.toId === s.toId
+        );
         return (
           <Row key={i}>
             <PersonAvatar person={from} size={26} />
@@ -32,6 +37,11 @@ function BalticiSettleUp() {
             <span style={{ opacity: 0.6 }}>→</span>
             <PersonAvatar person={to} size={26} />
             <span style={{ flex: 1, font: `400 14px/1 ${mono}` }}>{to.name}</span>
+            {pending && (
+              <span style={{ font: `700 10px/1 ${mono}`, letterSpacing: ".08em", border: "1px solid currentColor", padding: "5px 7px", opacity: 0.75, whiteSpace: "nowrap" }}>
+                🔒 {t("baltici.settle.pending")}
+              </span>
+            )}
             <span style={{ font: `700 14px/1 ${mono}` }}>{formatEuro(s.amountCents)}</span>
           </Row>
         );

--- a/packages/app/src/pages/baltici/BalticiSettledDebts.tsx
+++ b/packages/app/src/pages/baltici/BalticiSettledDebts.tsx
@@ -1,0 +1,131 @@
+import { useTranslation } from "react-i18next";
+import { useBaltici } from "../../baltici/store";
+import { useEditGate } from "../../baltici/editGate";
+import { UnlockBar } from "../../baltici/editGateUI";
+import { Row, EmptyState, SectionTitle, PAPER, INK } from "../../baltici/components/atoms";
+import { formatEuro } from "../../baltici/money";
+import type { Payment } from "../../baltici/model";
+
+const mono = "'Space Mono', monospace";
+
+// The settle-up ledger: claims waiting for the secret-word decision on top,
+// archived (confirmed) ones below. Claims are created from the Who owes tab.
+function BalticiSettledDebts() {
+  const { t } = useTranslation();
+  const { state, actions } = useBaltici();
+  const gate = useEditGate();
+
+  const nameOf = (id: string) => state.people.find((p) => p.id === id)?.name ?? "?";
+
+  const pending = state.payments.filter((p) => p.status === "pending");
+  const confirmed = state.payments.filter((p) => p.status === "confirmed");
+
+  return (
+    <div>
+      <SectionTitle>{t("baltici.settle.listTitle")}</SectionTitle>
+
+      <UnlockBar />
+
+      {state.payments.length === 0 && (
+        <EmptyState>{t("baltici.settle.emptyList")}</EmptyState>
+      )}
+
+      {pending.length > 0 && (
+        <>
+          <SectionTitle>{t("baltici.settle.pendingSection")}</SectionTitle>
+          {pending.map((p) => (
+            <PaymentRow
+              key={p.id}
+              p={p}
+              nameOf={nameOf}
+              canDecide={gate.canEdit}
+              onConfirm={() => actions.confirmPayment(p.id)}
+              onReject={() => actions.rejectPayment(p.id)}
+            />
+          ))}
+        </>
+      )}
+
+      {confirmed.length > 0 && (
+        <>
+          <SectionTitle>{t("baltici.settle.settledSection")}</SectionTitle>
+          {confirmed.map((p) => (
+            <PaymentRow key={p.id} p={p} nameOf={nameOf} canDecide={false} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** A settle-up claim row. Pending: locked, waiting for the secret-word decision
+ *  (the two buttons only show once unlocked). Confirmed: archived, grayed out. */
+function PaymentRow({
+  p,
+  nameOf,
+  canDecide,
+  onConfirm,
+  onReject,
+}: {
+  p: Payment;
+  nameOf: (id: string) => string;
+  canDecide: boolean;
+  onConfirm?: () => void;
+  onReject?: () => void;
+}) {
+  const { t } = useTranslation();
+  const confirmed = p.status === "confirmed";
+  return (
+    <Row style={{ alignItems: "flex-start", opacity: confirmed ? 0.45 : 1 }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ font: `700 14px/1.2 ${mono}` }}>
+          {nameOf(p.fromId)} → {nameOf(p.toId)}
+        </div>
+        <div style={{ font: `400 12px/1.4 ${mono}`, opacity: 0.7, marginTop: 2 }}>
+          {t("baltici.settle.via", { method: p.method })}
+        </div>
+      </div>
+      <div style={{ font: `700 14px/1 ${mono}`, whiteSpace: "nowrap" }}>{formatEuro(p.amountCents)}</div>
+      {confirmed ? (
+        <span style={badgeStyle}>{t("baltici.settle.settled")}</span>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+          <span style={badgeStyle}>🔒 {t("baltici.settle.pending")}</span>
+          {canDecide && (
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                type="button"
+                onClick={onConfirm}
+                style={{ ...btnStyle, border: `1.5px solid ${PAPER}`, background: PAPER, color: INK }}
+              >
+                {t("baltici.settle.confirm")}
+              </button>
+              <button type="button" onClick={onReject} style={btnStyle}>
+                {t("baltici.settle.reject")}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </Row>
+  );
+}
+
+const btnStyle = {
+  font: `700 11px/1 ${mono}`,
+  border: "1.5px solid currentColor",
+  background: "transparent",
+  color: "inherit",
+  padding: "6px 8px",
+  cursor: "pointer",
+} as const;
+
+const badgeStyle = {
+  font: `700 10px/1 ${mono}`,
+  letterSpacing: ".08em",
+  border: "1px solid currentColor",
+  padding: "5px 7px",
+  whiteSpace: "nowrap",
+} as const;
+
+export default BalticiSettledDebts;


### PR DESCRIPTION
## What

Per-person **settle-up in two phases** for the Baltici area:

1. **Claim (open to everyone):** every *Who owes* row has a **"✓ I'VE SETTLED UP"** button → modal with the debt pre-selected (pair + amount **frozen at click time**) and a required free-text method (PayPal, cash, …). Submitting creates a **pending** payment.
2. **Decision (secret word):** the new **SETTLED DEBTS** tab lists pending claims with the UnlockBar; once unlocked, **OK, SETTLED** archives the claim permanently (grayed-out row) and **NOT SETTLED** soft-deletes it without a trace (the debt reappears intact).

## Semantics
- A **pending** claim has **no effect on balances** — the debt stays counted (and badged 🔒 in *Who owes*) until confirmed. One pending claim per debtor→creditor pair.
- A **confirmed** claim applies as a **transfer** debtor → creditor in the balances. It is *not* an expense: the trip total is untouched. If the debt shrank below the frozen snapshot in the meantime, the debtor can end up in credit — correct, that money really changed hands.
- Expenses added between claim and confirmation simply accumulate as new debt; only the frozen snapshot is archived.
- People referenced by any payment can no longer be removed.

## Changes
- `model.ts` — `Payment` (pending|confirmed), `personIdsInPayment`, `GroupState.payments`
- `calc.ts` — `balances()` applies confirmed payments as transfers (pending ignored)
- `validation.ts` — `validatePayment` (people, amount, method, single pending per pair)
- `db.ts` — `payments` entity (soft-delete like the others)
- `store.ts` — payments mapping, `addPayment`/`confirmPayment`/`rejectPayment`, removePerson blocked by payments, `nowStamp` covers payments
- `SettleUpModal` (debt fixed, method-only) + per-row buttons in `BalticiSettleUp` + new `BalticiSettledDebts` page/tab/route
- i18n keys; 5 new calc unit tests (23 total)

## Verification
- Typecheck + lint + 23 unit tests + build green.
- Verified live against real data with **zero DB writes** (in-memory injected payments + stubbed transact): balance transfer math on screen, pending badge, claimable filtering, modal validation, decision buttons gating and payloads.
- Then **user-tested end-to-end for real** (claim created from the live UI, flow approved).

No new env vars; deploys with the existing Netlify setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)